### PR TITLE
Add initial implementations for vector DB / langchain4j embedding stores

### DIFF
--- a/core/forage-core-vectordb/pom.xml
+++ b/core/forage-core-vectordb/pom.xml
@@ -6,18 +6,18 @@
 
     <parent>
         <groupId>org.apache.camel.forage</groupId>
-        <artifactId>camel-forage</artifactId>
+        <artifactId>core</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>core</artifactId>
-    <packaging>pom</packaging>
-    <name>Camel Forage :: Core</name>
+    <artifactId>forage-core-vectordb</artifactId>
+    <name>Camel Forage :: Core :: VectorDB</name>
 
-    <modules>
-        <module>forage-core-common</module>
-        <module>forage-core-ai</module>
-        <module>forage-core-vectordb</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/core/forage-core-vectordb/pom.xml
+++ b/core/forage-core-vectordb/pom.xml
@@ -18,6 +18,10 @@
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/core/forage-core-vectordb/src/main/java/org/apache/camel/forage/core/vectordb/EmbeddingStoreFactory.java
+++ b/core/forage-core-vectordb/src/main/java/org/apache/camel/forage/core/vectordb/EmbeddingStoreFactory.java
@@ -1,0 +1,10 @@
+package org.apache.camel.forage.core.vectordb;
+
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.apache.camel.CamelContext;
+
+public interface EmbeddingStoreFactory {
+    void setCamelContext(CamelContext camelContext);
+
+    EmbeddingStore createEmbeddingStore();
+}

--- a/core/forage-core-vectordb/src/main/java/org/apache/camel/forage/core/vectordb/EmbeddingStoreProvider.java
+++ b/core/forage-core-vectordb/src/main/java/org/apache/camel/forage/core/vectordb/EmbeddingStoreProvider.java
@@ -9,7 +9,7 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 public interface EmbeddingStoreProvider {
 
     /**
-     * Creates a new model instance
+     * Creates a new EmbeddingStore instance
      * @return the created model
      */
     EmbeddingStore<TextSegment> newEmbeddingStore();

--- a/core/forage-core-vectordb/src/main/java/org/apache/camel/forage/core/vectordb/EmbeddingStoreProvider.java
+++ b/core/forage-core-vectordb/src/main/java/org/apache/camel/forage/core/vectordb/EmbeddingStoreProvider.java
@@ -1,0 +1,16 @@
+package org.apache.camel.forage.core.vectordb;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+
+/**
+ * Provider interface for creating AI embedding stores
+ */
+public interface EmbeddingStoreProvider {
+
+    /**
+     * Creates a new model instance
+     * @return the created model
+     */
+    EmbeddingStore<TextSegment> newEmbeddingStore();
+}

--- a/library/ai/vector-dbs/forage-vectordb-default/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-default/pom.xml
@@ -10,10 +10,14 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>forage-vectordb-weaviate</artifactId>
-    <name>Camel Forage :: Library :: AI :: Vector Databases :: Weaviate</name>
+    <artifactId>forage-vectordb-default</artifactId>
+    <name>Camel Forage :: Library :: AI :: Vector Databases :: Default</name>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-langchain4j-embeddingstore</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.camel.forage</groupId>
             <artifactId>forage-core-common</artifactId>
@@ -32,11 +36,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-weaviate</artifactId>
-            <version>${langchain4j-beta-version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/vector-dbs/forage-vectordb-default/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-default/pom.xml
@@ -17,6 +17,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-langchain4j-embeddingstore</artifactId>
+            <version>${camel.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.forage</groupId>
@@ -36,6 +37,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
+            <version>${langchain4j-version}</version>
         </dependency>
     </dependencies>
 

--- a/library/ai/vector-dbs/forage-vectordb-default/src/main/java/org/apache/camel/forage/vectordb/DefaultEmbeddingStoreFactory.java
+++ b/library/ai/vector-dbs/forage-vectordb-default/src/main/java/org/apache/camel/forage/vectordb/DefaultEmbeddingStoreFactory.java
@@ -1,0 +1,29 @@
+package org.apache.camel.forage.vectordb;
+
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.util.ServiceLoader;
+import org.apache.camel.CamelContext;
+import org.apache.camel.component.langchain4j.embeddingstore.EmbeddingStoreFactory;
+import org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider;
+
+public class DefaultEmbeddingStoreFactory implements EmbeddingStoreFactory {
+    private CamelContext camelContext;
+
+    @Override
+    public void setCamelContext(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @Override
+    public CamelContext getCamelContext() {
+        return camelContext;
+    }
+
+    @Override
+    public EmbeddingStore createEmbeddingStore() {
+        ServiceLoader<EmbeddingStoreProvider> providers = ServiceLoader.load(EmbeddingStoreProvider.class);
+        EmbeddingStoreProvider provider =
+                providers.findFirst().orElseThrow(() -> new IllegalStateException("No EmbeddingStoreProvider found"));
+        return provider.newEmbeddingStore();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-milvus/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/pom.xml
@@ -25,6 +25,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-agent-factory-default</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
         </dependency>

--- a/library/ai/vector-dbs/forage-vectordb-milvus/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>vectordbs</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-vectordb-milvus</artifactId>
+    <name>Camel Forage :: Library :: AI :: Vector Databases :: Milvus</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-vectordb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-milvus</artifactId>
+            <version>${langchain4j-beta-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/org/apache/camel/forage/vectordb/milvus/MilvusConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/org/apache/camel/forage/vectordb/milvus/MilvusConfig.java
@@ -1,0 +1,172 @@
+package org.apache.camel.forage.vectordb.milvus;
+
+import io.milvus.common.clientenum.ConsistencyLevelEnum;
+import io.milvus.param.IndexType;
+import io.milvus.param.MetricType;
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.core.util.config.MissingConfigException;
+
+public class MilvusConfig implements Config {
+
+    private static final ConfigModule HOST = ConfigModule.of(MilvusConfig.class, "host");
+    private static final ConfigModule PORT = ConfigModule.of(MilvusConfig.class, "port");
+    private static final ConfigModule COLLECTION_NAME = ConfigModule.of(MilvusConfig.class, "collection-name");
+    private static final ConfigModule DIMENSION = ConfigModule.of(MilvusConfig.class, "dimension");
+    private static final ConfigModule INDEX_TYPE = ConfigModule.of(MilvusConfig.class, "index-type");
+    private static final ConfigModule METRIC_TYPE = ConfigModule.of(MilvusConfig.class, "metric-type");
+    private static final ConfigModule URI = ConfigModule.of(MilvusConfig.class, "uri");
+    private static final ConfigModule TOKEN = ConfigModule.of(MilvusConfig.class, "token");
+    private static final ConfigModule USERNAME = ConfigModule.of(MilvusConfig.class, "username");
+    private static final ConfigModule PASSWORD = ConfigModule.of(MilvusConfig.class, "password");
+    private static final ConfigModule CONSISTENCY_LEVEL = ConfigModule.of(MilvusConfig.class, "consistency-level");
+    private static final ConfigModule RETRIEVE_EMBEDDINGS_ON_SEARCH =
+            ConfigModule.of(MilvusConfig.class, "retrieve-embeddings-on-search");
+    private static final ConfigModule AUTO_FLUSH_ON_INSERT =
+            ConfigModule.of(MilvusConfig.class, "auto-flush-on-insert");
+
+    private static final ConfigModule DATABASE_NAME = ConfigModule.of(MilvusConfig.class, "database-name");
+    private static final ConfigModule ID_FIELD_NAME = ConfigModule.of(MilvusConfig.class, "id-field-name");
+    private static final ConfigModule TEXT_FIELD_NAME = ConfigModule.of(MilvusConfig.class, "text-field-name");
+    private static final ConfigModule METADATA_FIELD_NAME = ConfigModule.of(MilvusConfig.class, "metadata-field-name");
+    private static final ConfigModule VECTOR_FIELD_NAME = ConfigModule.of(MilvusConfig.class, "vector-field-name");
+
+    public MilvusConfig() {
+        ConfigStore.getInstance().add(HOST, ConfigEntry.fromEnv("MILVUS_HOST"));
+        ConfigStore.getInstance().add(PORT, ConfigEntry.fromEnv("MILVUS_PORT"));
+        ConfigStore.getInstance().add(COLLECTION_NAME, ConfigEntry.fromEnv("MILVUS_COLLECTION_NAME"));
+        ConfigStore.getInstance().add(DIMENSION, ConfigEntry.fromEnv("MILVUS_DIMENSION"));
+        ConfigStore.getInstance().add(INDEX_TYPE, ConfigEntry.fromEnv("MILVUS_INDEX_TYPE"));
+        ConfigStore.getInstance().add(METRIC_TYPE, ConfigEntry.fromEnv("MILVUS_METRIC_TYPE"));
+        ConfigStore.getInstance().add(URI, ConfigEntry.fromEnv("MILVUS_URI"));
+        ConfigStore.getInstance().add(TOKEN, ConfigEntry.fromEnv("MILVUS_TOKEN"));
+        ConfigStore.getInstance().add(USERNAME, ConfigEntry.fromEnv("MILVUS_USERNAME"));
+        ConfigStore.getInstance().add(PASSWORD, ConfigEntry.fromEnv("MILVUS_PASSWORD"));
+        ConfigStore.getInstance().add(CONSISTENCY_LEVEL, ConfigEntry.fromEnv("MILVUS_CONSISTENCY_LEVEL"));
+        ConfigStore.getInstance()
+                .add(RETRIEVE_EMBEDDINGS_ON_SEARCH, ConfigEntry.fromEnv("MILVUS_RETRIEVE_EMBEDDINGS_ON_SEARCH"));
+        ConfigStore.getInstance().add(AUTO_FLUSH_ON_INSERT, ConfigEntry.fromEnv("MILVUS_AUTO_FLUSH_ON_INSERT"));
+        ConfigStore.getInstance().add(VECTOR_FIELD_NAME, ConfigEntry.fromEnv("MILVUS_ID_FIELD_NAME"));
+        ConfigStore.getInstance().add(VECTOR_FIELD_NAME, ConfigEntry.fromEnv("MILVUS_TEXT_FIELD_NAME"));
+        ConfigStore.getInstance().add(VECTOR_FIELD_NAME, ConfigEntry.fromEnv("MILVUS_METADATA_FIELD_NAME"));
+        ConfigStore.getInstance().add(VECTOR_FIELD_NAME, ConfigEntry.fromEnv("MILVUS_VECTOR_FIELD_NAME"));
+        ConfigStore.getInstance().add(MilvusConfig.class, this);
+    }
+
+    @Override
+    public String name() {
+        return "forage-vectordb-milvus";
+    }
+
+    public String host() {
+        return ConfigStore.getInstance().get(HOST).orElseThrow(() -> new MissingConfigException("Missing Milvus host"));
+    }
+
+    public Integer port() {
+        return ConfigStore.getInstance()
+                .get(PORT)
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Missing Milvus port"));
+    }
+
+    public String collectionName() {
+        return ConfigStore.getInstance().get(COLLECTION_NAME).orElse("default");
+    }
+
+    public Integer dimension() {
+        return ConfigStore.getInstance()
+                .get(DIMENSION)
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Missing Milvus dimension"));
+    }
+
+    public IndexType indexType() {
+        String indexType = ConfigStore.getInstance().get(INDEX_TYPE).orElse(null);
+
+        if (indexType != null) {
+            return IndexType.valueOf(indexType);
+        } else {
+            return IndexType.FLAT;
+        }
+    }
+
+    public MetricType metricType() {
+        String metricType = ConfigStore.getInstance().get(METRIC_TYPE).orElse(null);
+        if (metricType != null) {
+            return MetricType.valueOf(metricType);
+        } else {
+            return MetricType.COSINE;
+        }
+    }
+
+    public String uri() {
+        return ConfigStore.getInstance().get(URI).orElseThrow(() -> new MissingConfigException("Missing Milvus URI"));
+    }
+
+    public String token() {
+        return ConfigStore.getInstance()
+                .get(TOKEN)
+                .orElseThrow(() -> new MissingConfigException("Missing Milvus token"));
+    }
+
+    public String username() {
+        return ConfigStore.getInstance()
+                .get(USERNAME)
+                .orElseThrow(() -> new MissingConfigException("Missing Google username"));
+    }
+
+    public String password() {
+        return ConfigStore.getInstance()
+                .get(PASSWORD)
+                .orElseThrow(() -> new MissingConfigException("Missing Milvus password"));
+    }
+
+    public ConsistencyLevelEnum consistencyLevel() {
+        String consistencyLevel =
+                ConfigStore.getInstance().get(CONSISTENCY_LEVEL).orElse(null);
+
+        if (consistencyLevel != null) {
+            return ConsistencyLevelEnum.valueOf(consistencyLevel);
+        } else {
+            return ConsistencyLevelEnum.EVENTUALLY;
+        }
+    }
+
+    public Boolean retrieveEmbeddingsOnSearch() {
+        return ConfigStore.getInstance()
+                .get(RETRIEVE_EMBEDDINGS_ON_SEARCH)
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    public String databaseName() {
+        return ConfigStore.getInstance()
+                .get(DATABASE_NAME)
+                .orElseThrow(() -> new MissingConfigException("Missing Milvus database name"));
+    }
+
+    public String idFieldName() {
+        return ConfigStore.getInstance().get(ID_FIELD_NAME).orElse("id");
+    }
+
+    public String textFieldName() {
+        return ConfigStore.getInstance().get(TEXT_FIELD_NAME).orElse("text");
+    }
+
+    public String metadataFieldName() {
+        return ConfigStore.getInstance().get(METADATA_FIELD_NAME).orElse("metadata");
+    }
+
+    public String vectorFieldName() {
+        return ConfigStore.getInstance().get(VECTOR_FIELD_NAME).orElse("vector");
+    }
+
+    public Boolean autoFlushOnInsert() {
+        return ConfigStore.getInstance()
+                .get(AUTO_FLUSH_ON_INSERT)
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/org/apache/camel/forage/vectordb/milvus/MilvusProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/src/main/java/org/apache/camel/forage/vectordb/milvus/MilvusProvider.java
@@ -1,0 +1,36 @@
+package org.apache.camel.forage.vectordb.milvus;
+
+import dev.langchain4j.store.embedding.milvus.MilvusEmbeddingStore;
+import org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provider for creating Milvus Embedding Stores
+ */
+public class MilvusProvider implements EmbeddingStoreProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(MilvusProvider.class);
+
+    private static final MilvusConfig CONFIG = new MilvusConfig();
+
+    @Override
+    public MilvusEmbeddingStore newEmbeddingStore() {
+        LOG.trace("Creating Milvus Embedding Store");
+
+        return MilvusEmbeddingStore.builder()
+                .host(CONFIG.host())
+                .port(CONFIG.port())
+                .collectionName(CONFIG.collectionName())
+                .dimension(CONFIG.dimension())
+                .indexType(CONFIG.indexType())
+                .metricType(CONFIG.metricType())
+                .uri(CONFIG.uri())
+                .token(CONFIG.token())
+                .username(CONFIG.username())
+                .password(CONFIG.password())
+                .consistencyLevel(CONFIG.consistencyLevel())
+                .retrieveEmbeddingsOnSearch(CONFIG.retrieveEmbeddingsOnSearch())
+                .autoFlushOnInsert(CONFIG.autoFlushOnInsert())
+                .build();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-milvus/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
@@ -1,0 +1,2 @@
+org.apache.camel.forage.vectordb.milvus.MilvusProvider
+

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/pom.xml
@@ -25,6 +25,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-agent-factory-default</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
         </dependency>

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>vectordbs</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-vectordb-pgvector</artifactId>
+    <name>Camel Forage :: Library :: AI :: Vector Databases :: PgVector</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-vectordb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-pgvector</artifactId>
+            <version>${langchain4j-beta-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/java/org/apache/camel/forage/vectordb/pgvector/PgVectorConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/java/org/apache/camel/forage/vectordb/pgvector/PgVectorConfig.java
@@ -1,0 +1,123 @@
+package org.apache.camel.forage.vectordb.pgvector;
+
+import dev.langchain4j.store.embedding.pgvector.DefaultMetadataStorageConfig;
+import dev.langchain4j.store.embedding.pgvector.MetadataStorageConfig;
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.core.util.config.MissingConfigException;
+
+public class PgVectorConfig implements Config {
+
+    private static final ConfigModule HOST = ConfigModule.of(PgVectorConfig.class, "host");
+    private static final ConfigModule PORT = ConfigModule.of(PgVectorConfig.class, "port");
+    private static final ConfigModule USER = ConfigModule.of(PgVectorConfig.class, "user");
+    private static final ConfigModule PASSWORD = ConfigModule.of(PgVectorConfig.class, "password");
+    private static final ConfigModule DATABASE = ConfigModule.of(PgVectorConfig.class, "database");
+    private static final ConfigModule TABLE = ConfigModule.of(PgVectorConfig.class, "table");
+    private static final ConfigModule DIMENSION = ConfigModule.of(PgVectorConfig.class, "dimension");
+    private static final ConfigModule USE_INDEX = ConfigModule.of(PgVectorConfig.class, "use-index");
+    private static final ConfigModule INDEX_LIST_SIZE = ConfigModule.of(PgVectorConfig.class, "index-list-size");
+    private static final ConfigModule CREATE_TABLE = ConfigModule.of(PgVectorConfig.class, "create-table");
+    private static final ConfigModule DROP_TABLE_FIRST = ConfigModule.of(PgVectorConfig.class, "drop-table-first");
+    private static final ConfigModule METADATA_STORAGE_CONFIG =
+            ConfigModule.of(PgVectorConfig.class, "metadata-storage-config");
+
+    public PgVectorConfig() {
+        ConfigStore.getInstance().add(HOST, ConfigEntry.fromEnv("PGVECTOR_HOST"));
+        ConfigStore.getInstance().add(PORT, ConfigEntry.fromEnv("PGVECTOR_PORT"));
+        ConfigStore.getInstance().add(USER, ConfigEntry.fromEnv("PGVECTOR_USER"));
+        ConfigStore.getInstance().add(PASSWORD, ConfigEntry.fromEnv("PGVECTOR_PASSWORD"));
+        ConfigStore.getInstance().add(DATABASE, ConfigEntry.fromEnv("PGVECTOR_DATABASE"));
+        ConfigStore.getInstance().add(TABLE, ConfigEntry.fromEnv("PGVECTOR_TABLE"));
+        ConfigStore.getInstance().add(DIMENSION, ConfigEntry.fromEnv("PGVECTOR_DIMENSION"));
+        ConfigStore.getInstance().add(USE_INDEX, ConfigEntry.fromEnv("PGVECTOR_USE_INDEX"));
+        ConfigStore.getInstance().add(INDEX_LIST_SIZE, ConfigEntry.fromEnv("PGVECTOR_INDEX_LIST_SIZE"));
+        ConfigStore.getInstance().add(CREATE_TABLE, ConfigEntry.fromEnv("PGVECTOR_CREATE_TABLE"));
+        ConfigStore.getInstance().add(DROP_TABLE_FIRST, ConfigEntry.fromEnv("PGVECTOR_DROP_TABLE_FIRST"));
+        ConfigStore.getInstance().add(METADATA_STORAGE_CONFIG, ConfigEntry.fromEnv("PGVECTOR_METADATA_STORAGE_CONFIG"));
+        ConfigStore.getInstance().add(PgVectorConfig.class, this);
+    }
+
+    @Override
+    public String name() {
+        return "forage-vectordb-pgvector";
+    }
+
+    public String host() {
+        return ConfigStore.getInstance()
+                .get(HOST)
+                .orElseThrow(() -> new MissingConfigException("Missing PGVector host"));
+    }
+
+    public Integer port() {
+        return ConfigStore.getInstance()
+                .get(PORT)
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Missing PGVector port"));
+    }
+
+    public String user() {
+        return ConfigStore.getInstance()
+                .get(USER)
+                .orElseThrow(() -> new MissingConfigException("Missing PGVector user"));
+    }
+
+    public String password() {
+        return ConfigStore.getInstance()
+                .get(PASSWORD)
+                .orElseThrow(() -> new MissingConfigException("Missing PGVector password"));
+    }
+
+    public String database() {
+        return ConfigStore.getInstance()
+                .get(DATABASE)
+                .orElseThrow(() -> new MissingConfigException("Missing PGVector database"));
+    }
+
+    public String table() {
+        return ConfigStore.getInstance()
+                .get(TABLE)
+                .orElseThrow(() -> new MissingConfigException("Missing PGVector table"));
+    }
+
+    public Integer dimension() {
+        return ConfigStore.getInstance()
+                .get(DIMENSION)
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Missing PGVector dimension"));
+    }
+
+    public Boolean useIndex() {
+        return ConfigStore.getInstance()
+                .get(USE_INDEX)
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    public Integer indexListSize() {
+        return ConfigStore.getInstance()
+                .get(INDEX_LIST_SIZE)
+                .map(Integer::parseInt)
+                .orElse(100);
+    }
+
+    public Boolean createTable() {
+        return ConfigStore.getInstance()
+                .get(CREATE_TABLE)
+                .map(Boolean::parseBoolean)
+                .orElse(true);
+    }
+
+    public Boolean dropTableFirst() {
+        return ConfigStore.getInstance()
+                .get(DROP_TABLE_FIRST)
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    public MetadataStorageConfig metadataStorageConfig() {
+        return DefaultMetadataStorageConfig.defaultConfig();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/java/org/apache/camel/forage/vectordb/pgvector/PgVectorProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/java/org/apache/camel/forage/vectordb/pgvector/PgVectorProvider.java
@@ -1,0 +1,35 @@
+package org.apache.camel.forage.vectordb.pgvector;
+
+import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
+import org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provider for creating PgVector embedding stores
+ */
+public class PgVectorProvider implements EmbeddingStoreProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(PgVectorProvider.class);
+
+    private static final PgVectorConfig CONFIG = new PgVectorConfig();
+
+    @Override
+    public PgVectorEmbeddingStore newEmbeddingStore() {
+        LOG.trace("Creating PgVector Embedding Store");
+
+        return PgVectorEmbeddingStore.builder()
+                .host(CONFIG.host())
+                .port(CONFIG.port())
+                .user(CONFIG.user())
+                .password(CONFIG.password())
+                .database(CONFIG.database())
+                .table(CONFIG.table())
+                .dimension(CONFIG.dimension())
+                .useIndex(CONFIG.useIndex())
+                .indexListSize(CONFIG.indexListSize())
+                .createTable(CONFIG.createTable())
+                .dropTableFirst(CONFIG.dropTableFirst())
+                .metadataStorageConfig(CONFIG.metadataStorageConfig())
+                .build();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
@@ -1,0 +1,2 @@
+org.apache.camel.forage.vectordb.pgvector.PgVectorProvider
+

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>vectordbs</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-vectordb-pinecone</artifactId>
+    <name>Camel Forage :: Library :: AI :: Vector Databases :: Pinecone</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-vectordb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-pinecone</artifactId>
+            <version>${langchain4j-beta-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/org/apache/camel/forage/vectordb/pinecone/PineconeConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/org/apache/camel/forage/vectordb/pinecone/PineconeConfig.java
@@ -1,0 +1,102 @@
+package org.apache.camel.forage.vectordb.pinecone;
+
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.core.util.config.MissingConfigException;
+import org.openapitools.db_control.client.model.DeletionProtection;
+
+public class PineconeConfig implements Config {
+
+    private static final ConfigModule API_KEY = ConfigModule.of(PineconeConfig.class, "api-key");
+    private static final ConfigModule INDEX = ConfigModule.of(PineconeConfig.class, "index");
+    private static final ConfigModule NAME_SPACE = ConfigModule.of(PineconeConfig.class, "name-space");
+    private static final ConfigModule METADATA_TEXT_KEY = ConfigModule.of(PineconeConfig.class, "metadata-text-key");
+    private static final ConfigModule CREATE_INDEX = ConfigModule.of(PineconeConfig.class, "create-index");
+    private static final ConfigModule ENVIRONMENT = ConfigModule.of(PineconeConfig.class, "environment");
+    private static final ConfigModule PROJECT_ID = ConfigModule.of(PineconeConfig.class, "project-id");
+    private static final ConfigModule DIMENSION = ConfigModule.of(PineconeConfig.class, "dimension");
+    private static final ConfigModule CLOUD = ConfigModule.of(PineconeConfig.class, "cloud");
+    private static final ConfigModule REGION = ConfigModule.of(PineconeConfig.class, "region");
+    private static final ConfigModule DELETION_PROTECTION =
+            ConfigModule.of(PineconeConfig.class, "deletion-protection");
+
+    public PineconeConfig() {
+        ConfigStore.getInstance().add(API_KEY, ConfigEntry.fromEnv("PINECONE_API_KEY"));
+        ConfigStore.getInstance().add(INDEX, ConfigEntry.fromEnv("PINECONE_INDEX"));
+        ConfigStore.getInstance().add(NAME_SPACE, ConfigEntry.fromEnv("PINECONE_NAME_SPACE"));
+        ConfigStore.getInstance().add(METADATA_TEXT_KEY, ConfigEntry.fromEnv("PINECONE_METADATA_TEXT_KEY"));
+        ConfigStore.getInstance().add(CREATE_INDEX, ConfigEntry.fromEnv("PINECONE_CREATE_INDEX"));
+        ConfigStore.getInstance().add(ENVIRONMENT, ConfigEntry.fromEnv("PINECONE_ENVIRONMENT"));
+        ConfigStore.getInstance().add(PROJECT_ID, ConfigEntry.fromEnv("PINECONE_PROJECT_ID"));
+        ConfigStore.getInstance().add(DIMENSION, ConfigEntry.fromEnv("PINECONE_DIMENSION"));
+        ConfigStore.getInstance().add(CLOUD, ConfigEntry.fromEnv("PINECONE_CLOUD"));
+        ConfigStore.getInstance().add(REGION, ConfigEntry.fromEnv("PINECONE_REGION"));
+        ConfigStore.getInstance().add(DELETION_PROTECTION, ConfigEntry.fromEnv("PINECONE_DELETION_PROTECTION"));
+        ConfigStore.getInstance().add(PineconeConfig.class, this);
+    }
+
+    @Override
+    public String name() {
+        return "forage-vectordb-pinecone";
+    }
+
+    public String apiKey() {
+        return ConfigStore.getInstance()
+                .get(API_KEY)
+                .orElseThrow(() -> new MissingConfigException("Missing Google API key"));
+    }
+
+    public String index() {
+        return ConfigStore.getInstance()
+                .get(INDEX)
+                .orElseThrow(() -> new MissingConfigException("Missing Pinecone index"));
+    }
+
+    public String nameSpace() {
+        return ConfigStore.getInstance().get(NAME_SPACE).orElse("default");
+    }
+
+    public String metadataTextKey() {
+        return ConfigStore.getInstance().get(METADATA_TEXT_KEY).orElse("text_segment");
+    }
+
+    public String environment() {
+        return ConfigStore.getInstance()
+                .get(ENVIRONMENT)
+                .orElseThrow(() -> new MissingConfigException("Missing Pinecone environment"));
+    }
+
+    public String projectId() {
+        return ConfigStore.getInstance()
+                .get(PROJECT_ID)
+                .orElseThrow(() -> new MissingConfigException("Missing Pinecone project ID"));
+    }
+
+    public Integer dimension() {
+        return ConfigStore.getInstance()
+                .get(DIMENSION)
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Missing Pinecone dimension"));
+    }
+
+    public String cloud() {
+        return ConfigStore.getInstance()
+                .get(CLOUD)
+                .orElseThrow(() -> new MissingConfigException("Missing Pinecone cloud"));
+    }
+
+    public String region() {
+        return ConfigStore.getInstance()
+                .get(REGION)
+                .orElseThrow(() -> new MissingConfigException("Missing Pinecone region"));
+    }
+
+    public DeletionProtection deletionProtection() {
+        return ConfigStore.getInstance()
+                .get(DELETION_PROTECTION)
+                .map(DeletionProtection::valueOf)
+                .orElse(DeletionProtection.ENABLED);
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/org/apache/camel/forage/vectordb/pinecone/PineconeProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/java/org/apache/camel/forage/vectordb/pinecone/PineconeProvider.java
@@ -1,0 +1,30 @@
+package org.apache.camel.forage.vectordb.pinecone;
+
+import dev.langchain4j.store.embedding.pinecone.PineconeEmbeddingStore;
+import org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provider for creating Google Gemini chat models
+ */
+public class PineconeProvider implements EmbeddingStoreProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(PineconeProvider.class);
+
+    private static final PineconeConfig CONFIG = new PineconeConfig();
+
+    @Override
+    public PineconeEmbeddingStore newEmbeddingStore() {
+        LOG.trace("Creating pinecone embedding store");
+
+        return PineconeEmbeddingStore.builder()
+                .apiKey(CONFIG.apiKey())
+                .index(CONFIG.index())
+                .nameSpace(CONFIG.nameSpace())
+                .createIndex(null)
+                .metadataTextKey(CONFIG.metadataTextKey())
+                .environment(CONFIG.environment())
+                .projectId(CONFIG.projectId())
+                .build();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
@@ -1,0 +1,2 @@
+org.apache.camel.forage.vectordb.pinecone.PineconeProvider
+

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>vectordbs</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-vectordb-qdrant</artifactId>
+    <name>Camel Forage :: Library :: AI :: Vector Databases :: Qdrant</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-vectordb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-qdrant</artifactId>
+            <version>${langchain4j-beta-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/pom.xml
@@ -25,6 +25,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-agent-factory-default</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
         </dependency>

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/java/org/apache/camel/forage/vectordb/qdrant/QdrantConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/java/org/apache/camel/forage/vectordb/qdrant/QdrantConfig.java
@@ -1,0 +1,61 @@
+package org.apache.camel.forage.vectordb.qdrant;
+
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.core.util.config.MissingConfigException;
+
+public class QdrantConfig implements Config {
+
+    private static final ConfigModule COLLECTION_NAME = ConfigModule.of(QdrantConfig.class, "collection-name");
+    private static final ConfigModule HOST = ConfigModule.of(QdrantConfig.class, "host");
+    private static final ConfigModule PORT = ConfigModule.of(QdrantConfig.class, "port");
+    private static final ConfigModule USE_TLS = ConfigModule.of(QdrantConfig.class, "use-tls");
+    private static final ConfigModule PAYLOAD_TEXT_KEY = ConfigModule.of(QdrantConfig.class, "payload-text-key");
+    private static final ConfigModule API_KEY = ConfigModule.of(QdrantConfig.class, "api-key");
+
+    public QdrantConfig() {
+        ConfigStore.getInstance().add(COLLECTION_NAME, ConfigEntry.fromEnv("QDRANT_COLLECTION_NAME"));
+        ConfigStore.getInstance().add(HOST, ConfigEntry.fromEnv("QDRANT_HOST"));
+        ConfigStore.getInstance().add(PORT, ConfigEntry.fromEnv("QDRANT_PORT"));
+        ConfigStore.getInstance().add(USE_TLS, ConfigEntry.fromEnv("QDRANT_USE_TLS"));
+        ConfigStore.getInstance().add(PAYLOAD_TEXT_KEY, ConfigEntry.fromEnv("QDRANT_PAYLOAD_TEXT_KEY"));
+        ConfigStore.getInstance().add(API_KEY, ConfigEntry.fromEnv("QDRANT_API_KEY"));
+        ConfigStore.getInstance().add(QdrantConfig.class, this);
+    }
+
+    @Override
+    public String name() {
+        return "forage-vectordb-qdrant";
+    }
+
+    public String collectionName() {
+        return ConfigStore.getInstance()
+                .get(COLLECTION_NAME)
+                .orElseThrow(() -> new MissingConfigException("Missing Qdrant collection name"));
+    }
+
+    public String host() {
+        return ConfigStore.getInstance().get(HOST).orElseThrow(() -> new MissingConfigException("Missing Qdrant host"));
+    }
+
+    public Integer port() {
+        return ConfigStore.getInstance()
+                .get(PORT)
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Missing Qdrant port"));
+    }
+
+    public Boolean useTls() {
+        return ConfigStore.getInstance().get(USE_TLS).map(Boolean::parseBoolean).orElse(false);
+    }
+
+    public String payloadTextKey() {
+        return ConfigStore.getInstance().get(PAYLOAD_TEXT_KEY).orElse("text_segment");
+    }
+
+    public String apiKey() {
+        return ConfigStore.getInstance().get(API_KEY).orElse(null);
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/java/org/apache/camel/forage/vectordb/qdrant/QdrantProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/java/org/apache/camel/forage/vectordb/qdrant/QdrantProvider.java
@@ -1,0 +1,29 @@
+package org.apache.camel.forage.vectordb.qdrant;
+
+import dev.langchain4j.store.embedding.qdrant.QdrantEmbeddingStore;
+import org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provider for creating Qdrant embedding stores
+ */
+public class QdrantProvider implements EmbeddingStoreProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(QdrantProvider.class);
+
+    private static final QdrantConfig CONFIG = new QdrantConfig();
+
+    @Override
+    public QdrantEmbeddingStore newEmbeddingStore() {
+        LOG.trace("Creating qdrant embedding store");
+
+        return QdrantEmbeddingStore.builder()
+                .collectionName(CONFIG.collectionName())
+                .apiKey(CONFIG.apiKey())
+                .host(CONFIG.host())
+                .port(CONFIG.port())
+                .useTls(CONFIG.useTls())
+                .payloadTextKey(CONFIG.payloadTextKey())
+                .build();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
@@ -1,0 +1,2 @@
+org.apache.camel.forage.vectordb.qdrant.QdrantProvider
+

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>vectordbs</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-vectordb-weaviate</artifactId>
+    <name>Camel Forage :: Library :: AI :: Vector Databases :: Weaviate</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-vectordb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-weaviate</artifactId>
+            <version>${langchain4j-beta-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/org/apache/camel/forage/vectordb/weaviate/WeaviateConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/org/apache/camel/forage/vectordb/weaviate/WeaviateConfig.java
@@ -1,0 +1,128 @@
+package org.apache.camel.forage.vectordb.weaviate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.core.util.config.MissingConfigException;
+
+public class WeaviateConfig implements Config {
+
+    private static final ConfigModule API_KEY = ConfigModule.of(WeaviateConfig.class, "api-key");
+    private static final ConfigModule SCHEME = ConfigModule.of(WeaviateConfig.class, "scheme");
+    private static final ConfigModule HOST = ConfigModule.of(WeaviateConfig.class, "host");
+    private static final ConfigModule PORT = ConfigModule.of(WeaviateConfig.class, "port");
+    private static final ConfigModule USE_GRPC_FOR_INSERTS =
+            ConfigModule.of(WeaviateConfig.class, "use-grpc-for-inserts");
+    private static final ConfigModule SECURED_GRPC = ConfigModule.of(WeaviateConfig.class, "secured-grpc");
+    private static final ConfigModule GRPC_PORT = ConfigModule.of(WeaviateConfig.class, "grpc-port");
+    private static final ConfigModule OBJECT_CLASS = ConfigModule.of(WeaviateConfig.class, "object-class");
+    private static final ConfigModule AVOID_DUPS = ConfigModule.of(WeaviateConfig.class, "avoid-dups");
+    private static final ConfigModule CONSISTENCY_LEVEL = ConfigModule.of(WeaviateConfig.class, "consistency-level");
+    private static final ConfigModule METADATA_KEYS = ConfigModule.of(WeaviateConfig.class, "metadata-keys");
+    private static final ConfigModule TEXT_FIELD_NAME = ConfigModule.of(WeaviateConfig.class, "text-field-name");
+    private static final ConfigModule METADATA_FIELD_NAME =
+            ConfigModule.of(WeaviateConfig.class, "metadata-field-name");
+
+    public WeaviateConfig() {
+        ConfigStore.getInstance().add(API_KEY, ConfigEntry.fromEnv("WEAVIATE_API_KEY"));
+        ConfigStore.getInstance().add(SCHEME, ConfigEntry.fromEnv("WEAVIATE_SCHEME"));
+        ConfigStore.getInstance().add(HOST, ConfigEntry.fromEnv("WEAVIATE_HOST"));
+        ConfigStore.getInstance().add(PORT, ConfigEntry.fromEnv("WEAVIATE_PORT"));
+        ConfigStore.getInstance().add(USE_GRPC_FOR_INSERTS, ConfigEntry.fromEnv("WEAVIATE_USE_GRPC_FOR_INSERTS"));
+        ConfigStore.getInstance().add(SECURED_GRPC, ConfigEntry.fromEnv("WEAVIATE_SECURED_GRPC"));
+        ConfigStore.getInstance().add(GRPC_PORT, ConfigEntry.fromEnv("WEAVIATE_GRPC_PORT"));
+        ConfigStore.getInstance().add(OBJECT_CLASS, ConfigEntry.fromEnv("WEAVIATE_OBJECT_CLASS"));
+        ConfigStore.getInstance().add(AVOID_DUPS, ConfigEntry.fromEnv("WEAVIATE_AVOID_DUPS"));
+        ConfigStore.getInstance().add(CONSISTENCY_LEVEL, ConfigEntry.fromEnv("WEAVIATE_CONSISTENCY_LEVEL"));
+        ConfigStore.getInstance().add(METADATA_KEYS, ConfigEntry.fromEnv("WEAVIATE_METADATA_KEYS"));
+        ConfigStore.getInstance().add(TEXT_FIELD_NAME, ConfigEntry.fromEnv("WEAVIATE_TEXT_FIELD_NAME"));
+        ConfigStore.getInstance().add(METADATA_FIELD_NAME, ConfigEntry.fromEnv("WEAVIATE_METADATA_FIELD_NAME"));
+        ConfigStore.getInstance().add(WeaviateConfig.class, this);
+    }
+
+    @Override
+    public String name() {
+        return "forage-vectordb-weaviate";
+    }
+
+    public String apiKey() {
+        return ConfigStore.getInstance()
+                .get(API_KEY)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate API key"));
+    }
+
+    public String scheme() {
+        return ConfigStore.getInstance()
+                .get(SCHEME)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate scheme"));
+    }
+
+    public String host() {
+        return ConfigStore.getInstance()
+                .get(HOST)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate host"));
+    }
+
+    public Integer port() {
+        return ConfigStore.getInstance()
+                .get(PORT)
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate port"));
+    }
+
+    public Boolean useGrpcForInserts() {
+        return ConfigStore.getInstance()
+                .get(USE_GRPC_FOR_INSERTS)
+                .map(Boolean::parseBoolean)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate use grpc for inserts"));
+    }
+
+    public Boolean securedGrpc() {
+        return ConfigStore.getInstance()
+                .get(SECURED_GRPC)
+                .map(Boolean::parseBoolean)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate secured grpc"));
+    }
+
+    public Integer grpcPort() {
+        return ConfigStore.getInstance()
+                .get(GRPC_PORT)
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate grpc port"));
+    }
+
+    public String objectClass() {
+        return ConfigStore.getInstance()
+                .get(OBJECT_CLASS)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate object class"));
+    }
+
+    public Boolean avoidDups() {
+        return ConfigStore.getInstance()
+                .get(AVOID_DUPS)
+                .map(Boolean::parseBoolean)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate avoid dups"));
+    }
+
+    public String consistencyLevel() {
+        return ConfigStore.getInstance()
+                .get(CONSISTENCY_LEVEL)
+                .orElseThrow(() -> new MissingConfigException("Missing Weaviate consistency level"));
+    }
+
+    public Collection<String> metadataKeys() {
+        return ConfigStore.getInstance().get(METADATA_KEYS).map(Arrays::asList).orElse(Collections.emptyList());
+    }
+
+    public String textFieldName() {
+        return ConfigStore.getInstance().get(TEXT_FIELD_NAME).orElse("text");
+    }
+
+    public String metadataFieldName() {
+        return ConfigStore.getInstance().get(METADATA_FIELD_NAME).orElse("_metadata");
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/org/apache/camel/forage/vectordb/weaviate/WeaviateProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/org/apache/camel/forage/vectordb/weaviate/WeaviateProvider.java
@@ -1,0 +1,36 @@
+package org.apache.camel.forage.vectordb.weaviate;
+
+import dev.langchain4j.store.embedding.weaviate.WeaviateEmbeddingStore;
+import org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provider for creating Google Gemini chat models
+ */
+public class WeaviateProvider implements EmbeddingStoreProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(WeaviateProvider.class);
+
+    private static final WeaviateConfig CONFIG = new WeaviateConfig();
+
+    @Override
+    public WeaviateEmbeddingStore newEmbeddingStore() {
+        LOG.trace("Creating weaviate embedding store");
+
+        return WeaviateEmbeddingStore.builder()
+                .apiKey(CONFIG.apiKey())
+                .scheme(CONFIG.scheme())
+                .host(CONFIG.host())
+                .port(CONFIG.port())
+                .useGrpcForInserts(CONFIG.useGrpcForInserts())
+                .securedGrpc(CONFIG.securedGrpc())
+                .grpcPort(CONFIG.grpcPort())
+                .objectClass(CONFIG.objectClass())
+                .avoidDups(CONFIG.avoidDups())
+                .consistencyLevel(CONFIG.consistencyLevel())
+                .metadataKeys(CONFIG.metadataKeys())
+                .textFieldName(CONFIG.textFieldName())
+                .metadataFieldName(CONFIG.metadataFieldName())
+                .build();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
@@ -1,0 +1,2 @@
+org.apache.camel.forage.vectordb.weaviate.WeaviateProvider
+

--- a/library/ai/vector-dbs/pom.xml
+++ b/library/ai/vector-dbs/pom.xml
@@ -10,7 +10,16 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>vector-dbs</artifactId>
+    <artifactId>vectordbs</artifactId>
+    <packaging>pom</packaging>
     <name>Camel Forage :: Library :: AI :: Vector Databases</name>
+
+    <modules>
+        <module>forage-vectordb-milvus</module>
+        <module>forage-vectordb-pgvector</module>
+        <module>forage-vectordb-pinecone</module>
+        <module>forage-vectordb-qdrant</module>
+        <module>forage-vectordb-weaviate</module>
+    </modules>
 
 </project>

--- a/library/ai/vector-dbs/pom.xml
+++ b/library/ai/vector-dbs/pom.xml
@@ -15,6 +15,7 @@
     <name>Camel Forage :: Library :: AI :: Vector Databases</name>
 
     <modules>
+        <module>forage-vectordb-default</module>
         <module>forage-vectordb-milvus</module>
         <module>forage-vectordb-pgvector</module>
         <module>forage-vectordb-pinecone</module>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <camel.version>4.14.0-SNAPSHOT</camel.version>
         <langchain4j-version>1.2.0</langchain4j-version>
+        <langchain4j-beta-version>1.3.0-beta9</langchain4j-beta-version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.21.1</log4j.version>
         <spotless.version>2.43.0</spotless.version>


### PR DESCRIPTION
Adding initial implementations for vector DB / langchain4j embedding stores.     This PR adds Milvus, PGVector, Pinecone, Qdrant and Weaviate support, will add more implementations for additional vector db / embedding stores in the future.