### PR TITLE
Add Memory Redis

### DIFF
--- a/library/ai/chat-memory/forage-memory-redis/pom.xml
+++ b/library/ai/chat-memory/forage-memory-redis/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>chat-memory</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-memory-redis</artifactId>
+    <packaging>jar</packaging>
+    <name>Camel Forage :: Library :: AI :: Chat Memory :: Redis</name>
+
+    <properties>
+        <jedis.version>6.1.0</jedis.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-langchain4j-agent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>${jedis.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/org/apache/camel/forage/memory/chat/redis/PersistentRedisStore.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/org/apache/camel/forage/memory/chat/redis/PersistentRedisStore.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.forage.memory.chat.redis;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisException;
+
+/**
+ * Redis-based implementation of {@link ChatMemoryStore} that provides persistent storage
+ * for chat conversation history using Redis as the backing store.
+ *
+ * <p>This implementation stores chat messages as JSON-serialized data in Redis, with each
+ * conversation identified by a unique memory ID. The store supports the full lifecycle
+ * of chat memory operations including retrieval, updates, and deletion.
+ *
+ * <p><strong>Key Features:</strong>
+ * <ul>
+ *   <li>Persistent storage of chat conversations across application restarts</li>
+ *   <li>Automatic JSON serialization/deserialization of chat messages</li>
+ *   <li>Connection pooling via {@link JedisPool} for optimal performance</li>
+ *   <li>UTF-8 encoding for proper international character support</li>
+ *   <li>Robust error handling with proper resource cleanup</li>
+ * </ul>
+ *
+ * <p><strong>Redis Key Structure:</strong>
+ * Each conversation is stored with the memory ID as the Redis key, containing a JSON array
+ * of serialized {@link ChatMessage} objects. Empty conversations are represented as empty lists.
+ *
+ * <p><strong>Thread Safety:</strong>
+ * This class is thread-safe as it uses a connection pool and ensures proper resource
+ * cleanup for each operation. Multiple threads can safely access different conversations
+ * concurrently.
+ *
+ * <p><strong>Error Handling:</strong>
+ * Redis connection failures and serialization errors are properly handled and logged.
+ * Failed operations will not leave connections in an inconsistent state.
+ *
+ * @see ChatMemoryStore
+ * @see JedisPool
+ * @since 1.0
+ */
+public class PersistentRedisStore implements ChatMemoryStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PersistentRedisStore.class);
+    private static final String EMPTY_MESSAGES_JSON = "[]";
+
+    private final JedisPool jedisPool;
+
+    /**
+     * Creates a new Redis-based chat memory store.
+     *
+     * @param jedisPool the Redis connection pool to use for database operations, must not be {@code null}
+     * @throws NullPointerException if jedisPool is null
+     */
+    public PersistentRedisStore(JedisPool jedisPool) {
+        this.jedisPool = Objects.requireNonNull(jedisPool, "JedisPool cannot be null");
+    }
+
+    /**
+     * Deletes all chat messages for the specified memory ID.
+     *
+     * <p>This operation removes the entire conversation history from Redis.
+     * If the memory ID does not exist, this operation is idempotent and will
+     * not raise an error.
+     *
+     * @param memoryId the unique identifier for the conversation to delete, must not be {@code null}
+     * @throws NullPointerException if memoryId is null
+     * @throws RuntimeException if a Redis operation fails
+     */
+    @Override
+    public void deleteMessages(Object memoryId) {
+        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+
+        String key = memoryId.toString();
+        try (Jedis jedis = jedisPool.getResource()) {
+            long deleted = jedis.del(key);
+            LOG.debug("Deleted {} conversation(s) for memory ID: {}", deleted, key);
+        } catch (JedisException e) {
+            LOG.error("Failed to delete messages for memory ID: {}", key, e);
+            throw new RuntimeException("Failed to delete chat messages from Redis", e);
+        }
+    }
+
+    /**
+     * Retrieves all chat messages for the specified memory ID.
+     *
+     * <p>Returns the complete conversation history as a list of {@link ChatMessage} objects.
+     * If no conversation exists for the given memory ID, an empty list is returned.
+     *
+     * @param memoryId the unique identifier for the conversation to retrieve, must not be {@code null}
+     * @return a list of chat messages for the conversation, never {@code null} but may be empty
+     * @throws NullPointerException if memoryId is null
+     * @throws RuntimeException if a Redis operation or deserialization fails
+     */
+    @Override
+    public List<ChatMessage> getMessages(Object memoryId) {
+        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+
+        String key = memoryId.toString();
+        try (Jedis jedis = jedisPool.getResource()) {
+            byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+            byte[] bytes = jedis.get(keyBytes);
+
+            if (bytes == null) {
+                LOG.debug("No messages found for memory ID: {}", key);
+                return Collections.emptyList();
+            }
+
+            String json = new String(bytes, StandardCharsets.UTF_8);
+            if (json.isEmpty() || EMPTY_MESSAGES_JSON.equals(json)) {
+                return Collections.emptyList();
+            }
+
+            List<ChatMessage> messages = ChatMessageDeserializer.messagesFromJson(json);
+            LOG.debug("Retrieved {} messages for memory ID: {}", messages.size(), key);
+            return messages;
+        } catch (JedisException e) {
+            LOG.error("Failed to retrieve messages for memory ID: {}", key, e);
+            throw new RuntimeException("Failed to retrieve chat messages from Redis", e);
+        } catch (Exception e) {
+            LOG.error("Failed to deserialize messages for memory ID: {}", key, e);
+            throw new RuntimeException("Failed to deserialize chat messages", e);
+        }
+    }
+
+    /**
+     * Updates the chat messages for the specified memory ID.
+     *
+     * <p>This operation replaces the entire conversation history with the provided messages.
+     * The messages are serialized to JSON format and stored in Redis. If the messages list
+     * is empty, an empty conversation is stored (not deleted).
+     *
+     * @param memoryId the unique identifier for the conversation to update, must not be {@code null}
+     * @param messages the complete list of messages for the conversation, must not be {@code null}
+     * @throws NullPointerException if memoryId or messages is null
+     * @throws RuntimeException if a Redis operation or serialization fails
+     */
+    @Override
+    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+        Objects.requireNonNull(messages, "Messages list cannot be null");
+
+        String key = memoryId.toString();
+        try (Jedis jedis = jedisPool.getResource()) {
+            String json = ChatMessageSerializer.messagesToJson(messages);
+            byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+            byte[] messageBytes = json.getBytes(StandardCharsets.UTF_8);
+
+            jedis.set(keyBytes, messageBytes);
+            LOG.debug("Updated {} messages for memory ID: {}", messages.size(), key);
+        } catch (JedisException e) {
+            LOG.error("Failed to update messages for memory ID: {}", key, e);
+            throw new RuntimeException("Failed to update chat messages in Redis", e);
+        } catch (Exception e) {
+            LOG.error("Failed to serialize messages for memory ID: {}", key, e);
+            throw new RuntimeException("Failed to serialize chat messages", e);
+        }
+    }
+}

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/org/apache/camel/forage/memory/chat/redis/RedisConfig.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/org/apache/camel/forage/memory/chat/redis/RedisConfig.java
@@ -1,0 +1,417 @@
+package org.apache.camel.forage.memory.chat.redis;
+
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+
+/**
+ * Configuration class for Redis-based chat memory storage in the Camel Forage framework.
+ *
+ * <p>This configuration manages connection parameters for Redis instances used to store
+ * persistent chat conversation history. It follows the standard Camel Forage configuration
+ * pattern with support for multiple configuration sources and environment-specific overrides.
+ *
+ * <p><strong>Configuration Properties:</strong>
+ * <ul>
+ *   <li><code>redis.host</code> - Redis server hostname (default: localhost) - required</li>
+ *   <li><code>redis.port</code> - Redis server port (default: 6379) - required</li>
+ *   <li><code>redis.password</code> - Redis authentication password (optional)</li>
+ *   <li><code>redis.database</code> - Redis database number (default: 0)</li>
+ *   <li><code>redis.timeout</code> - Connection timeout in milliseconds (default: 2000)</li>
+ *   <li><code>redis.pool.max-total</code> - Maximum number of connections in the pool (default: 10)</li>
+ *   <li><code>redis.pool.max-idle</code> - Maximum number of idle connections (default: 5)</li>
+ *   <li><code>redis.pool.min-idle</code> - Minimum number of idle connections (default: 1)</li>
+ *   <li><code>redis.pool.test-on-borrow</code> - Test connections when borrowing from pool (default: true)</li>
+ *   <li><code>redis.pool.test-on-return</code> - Test connections when returning to pool (default: true)</li>
+ *   <li><code>redis.pool.test-while-idle</code> - Test idle connections periodically (default: true)</li>
+ *   <li><code>redis.pool.max-wait-millis</code> - Maximum time to wait for a connection (default: 2000)</li>
+ * </ul>
+ *
+ * <p><strong>Configuration Sources (in order of precedence):</strong>
+ * <ol>
+ *   <li>Environment variables: {@code REDIS_HOST}, {@code REDIS_PORT}, {@code REDIS_PASSWORD}, {@code REDIS_POOL_MAX_TOTAL}, etc.</li>
+ *   <li>System properties: {@code redis.host}, {@code redis.port}, {@code redis.password}, {@code redis.pool.max-total}, etc.</li>
+ *   <li>Configuration file: {@code forage-memory-redis.properties}</li>
+ *   <li>Default values where applicable</li>
+ * </ol>
+ *
+ * <p><strong>Example Environment Configuration:</strong>
+ * <pre>{@code
+ * export REDIS_HOST=redis.example.com
+ * export REDIS_PORT=6379
+ * export REDIS_PASSWORD=secret123
+ * export REDIS_DATABASE=1
+ * export REDIS_POOL_MAX_TOTAL=20
+ * export REDIS_POOL_MAX_IDLE=10
+ * }</pre>
+ *
+ * <p><strong>Example System Properties:</strong>
+ * <pre>{@code
+ * -Dredis.host=redis.example.com
+ * -Dredis.port=6379
+ * -Dredis.password=secret123
+ * -Dredis.database=1
+ * -Dredis.pool.max-total=20
+ * -Dredis.pool.max-idle=10
+ * }</pre>
+ *
+ * <p><strong>Example Properties File (forage-memory-redis.properties):</strong>
+ * <pre>
+ * redis.host=redis.example.com
+ * redis.port=6379
+ * redis.password=secret123
+ * redis.database=1
+ * redis.timeout=5000
+ * redis.pool.max-total=20
+ * redis.pool.max-idle=10
+ * redis.pool.min-idle=2
+ * redis.pool.test-on-borrow=true
+ * redis.pool.max-wait-millis=3000
+ * </pre>
+ *
+ * @see Config
+ * @see ConfigStore
+ * @see PersistentRedisStore
+ * @since 1.0
+ */
+public class RedisConfig implements Config {
+
+    private static final ConfigModule HOST = ConfigModule.of(RedisConfig.class, "redis.host");
+    private static final ConfigModule PORT = ConfigModule.of(RedisConfig.class, "redis.port");
+    private static final ConfigModule PASSWORD = ConfigModule.of(RedisConfig.class, "redis.password");
+    private static final ConfigModule DATABASE = ConfigModule.of(RedisConfig.class, "redis.database");
+    private static final ConfigModule TIMEOUT = ConfigModule.of(RedisConfig.class, "redis.timeout");
+
+    // Pool configuration
+    private static final ConfigModule POOL_MAX_TOTAL = ConfigModule.of(RedisConfig.class, "redis.pool.max-total");
+    private static final ConfigModule POOL_MAX_IDLE = ConfigModule.of(RedisConfig.class, "redis.pool.max-idle");
+    private static final ConfigModule POOL_MIN_IDLE = ConfigModule.of(RedisConfig.class, "redis.pool.min-idle");
+    private static final ConfigModule POOL_TEST_ON_BORROW =
+            ConfigModule.of(RedisConfig.class, "redis.pool.test-on-borrow");
+    private static final ConfigModule POOL_TEST_ON_RETURN =
+            ConfigModule.of(RedisConfig.class, "redis.pool.test-on-return");
+    private static final ConfigModule POOL_TEST_WHILE_IDLE =
+            ConfigModule.of(RedisConfig.class, "redis.pool.test-while-idle");
+    private static final ConfigModule POOL_MAX_WAIT_MILLIS =
+            ConfigModule.of(RedisConfig.class, "redis.pool.max-wait-millis");
+
+    /**
+     * Creates a new Redis configuration instance and registers configuration entries
+     * with the central {@link ConfigStore}.
+     *
+     * <p>This constructor automatically registers all Redis configuration parameters
+     * and their corresponding environment variable mappings. It also sets up the
+     * configuration loader to process property files if they exist.
+     */
+    public RedisConfig() {
+        ConfigStore.getInstance().add(HOST, ConfigEntry.fromEnv("REDIS_HOST"));
+        ConfigStore.getInstance().add(PORT, ConfigEntry.fromEnv("REDIS_PORT"));
+        ConfigStore.getInstance().add(PASSWORD, ConfigEntry.fromEnv("REDIS_PASSWORD"));
+        ConfigStore.getInstance().add(DATABASE, ConfigEntry.fromEnv("REDIS_DATABASE"));
+        ConfigStore.getInstance().add(TIMEOUT, ConfigEntry.fromEnv("REDIS_TIMEOUT"));
+
+        // Pool configuration
+        ConfigStore.getInstance().add(POOL_MAX_TOTAL, ConfigEntry.fromEnv("REDIS_POOL_MAX_TOTAL"));
+        ConfigStore.getInstance().add(POOL_MAX_IDLE, ConfigEntry.fromEnv("REDIS_POOL_MAX_IDLE"));
+        ConfigStore.getInstance().add(POOL_MIN_IDLE, ConfigEntry.fromEnv("REDIS_POOL_MIN_IDLE"));
+        ConfigStore.getInstance().add(POOL_TEST_ON_BORROW, ConfigEntry.fromEnv("REDIS_POOL_TEST_ON_BORROW"));
+        ConfigStore.getInstance().add(POOL_TEST_ON_RETURN, ConfigEntry.fromEnv("REDIS_POOL_TEST_ON_RETURN"));
+        ConfigStore.getInstance().add(POOL_TEST_WHILE_IDLE, ConfigEntry.fromEnv("REDIS_POOL_TEST_WHILE_IDLE"));
+        ConfigStore.getInstance().add(POOL_MAX_WAIT_MILLIS, ConfigEntry.fromEnv("REDIS_POOL_MAX_WAIT_MILLIS"));
+
+        ConfigStore.getInstance().add(RedisConfig.class, this, this::register);
+    }
+
+    /**
+     * Returns the Redis server hostname.
+     *
+     * @return the Redis server hostname, defaults to "localhost" if not configured
+     */
+    public String host() {
+        return ConfigStore.getInstance().get(HOST).orElse("localhost");
+    }
+
+    /**
+     * Returns the Redis server port number.
+     *
+     * @return the Redis server port, defaults to 6379 (standard Redis port) if not configured
+     * @throws NumberFormatException if the configured port value is not a valid integer
+     */
+    public int port() {
+        return ConfigStore.getInstance()
+                .get(PORT)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Redis port number: " + value, e);
+                    }
+                })
+                .orElse(6379);
+    }
+
+    /**
+     * Returns the Redis authentication password.
+     *
+     * @return the Redis password, or {@code null} if no authentication is required
+     */
+    public String password() {
+        return ConfigStore.getInstance().get(PASSWORD).orElse(null);
+    }
+
+    /**
+     * Returns the Redis database number to connect to.
+     *
+     * @return the Redis database number, defaults to 0 if not configured
+     * @throws NumberFormatException if the configured database value is not a valid integer
+     */
+    public int database() {
+        return ConfigStore.getInstance()
+                .get(DATABASE)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Redis database number: " + value, e);
+                    }
+                })
+                .orElse(0);
+    }
+
+    /**
+     * Returns the Redis connection timeout in milliseconds.
+     *
+     * @return the connection timeout in milliseconds, defaults to 2000ms if not configured
+     * @throws NumberFormatException if the configured timeout value is not a valid integer
+     */
+    public int timeout() {
+        return ConfigStore.getInstance()
+                .get(TIMEOUT)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Redis timeout value: " + value, e);
+                    }
+                })
+                .orElse(2000);
+    }
+
+    /**
+     * Returns the maximum number of connections in the Redis connection pool.
+     *
+     * @return the maximum total connections, defaults to 10 if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid integer
+     */
+    public int poolMaxTotal() {
+        return ConfigStore.getInstance()
+                .get(POOL_MAX_TOTAL)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Redis pool max-total value: " + value, e);
+                    }
+                })
+                .orElse(10);
+    }
+
+    /**
+     * Returns the maximum number of idle connections in the Redis connection pool.
+     *
+     * @return the maximum idle connections, defaults to 5 if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid integer
+     */
+    public int poolMaxIdle() {
+        return ConfigStore.getInstance()
+                .get(POOL_MAX_IDLE)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Redis pool max-idle value: " + value, e);
+                    }
+                })
+                .orElse(5);
+    }
+
+    /**
+     * Returns the minimum number of idle connections in the Redis connection pool.
+     *
+     * @return the minimum idle connections, defaults to 1 if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid integer
+     */
+    public int poolMinIdle() {
+        return ConfigStore.getInstance()
+                .get(POOL_MIN_IDLE)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Redis pool min-idle value: " + value, e);
+                    }
+                })
+                .orElse(1);
+    }
+
+    /**
+     * Returns whether to test connections when borrowing from the pool.
+     *
+     * @return true if connections should be tested on borrow, defaults to true if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid boolean
+     */
+    public boolean poolTestOnBorrow() {
+        return ConfigStore.getInstance()
+                .get(POOL_TEST_ON_BORROW)
+                .map(value -> {
+                    if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+                        return Boolean.parseBoolean(value);
+                    }
+                    throw new IllegalArgumentException(
+                            "Invalid Redis pool test-on-borrow value: " + value + " (must be true or false)");
+                })
+                .orElse(true);
+    }
+
+    /**
+     * Returns whether to test connections when returning to the pool.
+     *
+     * @return true if connections should be tested on return, defaults to true if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid boolean
+     */
+    public boolean poolTestOnReturn() {
+        return ConfigStore.getInstance()
+                .get(POOL_TEST_ON_RETURN)
+                .map(value -> {
+                    if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+                        return Boolean.parseBoolean(value);
+                    }
+                    throw new IllegalArgumentException(
+                            "Invalid Redis pool test-on-return value: " + value + " (must be true or false)");
+                })
+                .orElse(true);
+    }
+
+    /**
+     * Returns whether to test idle connections periodically.
+     *
+     * @return true if idle connections should be tested, defaults to true if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid boolean
+     */
+    public boolean poolTestWhileIdle() {
+        return ConfigStore.getInstance()
+                .get(POOL_TEST_WHILE_IDLE)
+                .map(value -> {
+                    if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+                        return Boolean.parseBoolean(value);
+                    }
+                    throw new IllegalArgumentException(
+                            "Invalid Redis pool test-while-idle value: " + value + " (must be true or false)");
+                })
+                .orElse(true);
+    }
+
+    /**
+     * Returns the maximum time to wait for a connection from the pool in milliseconds.
+     *
+     * @return the maximum wait time in milliseconds, defaults to 2000ms if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid integer
+     */
+    public int poolMaxWaitMillis() {
+        return ConfigStore.getInstance()
+                .get(POOL_MAX_WAIT_MILLIS)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Redis pool max-wait-millis value: " + value, e);
+                    }
+                })
+                .orElse(2000);
+    }
+
+    /**
+     * Resolves a configuration property name to its corresponding {@link ConfigModule}.
+     *
+     * <p>This method is used during configuration loading to map property names from
+     * configuration files to their respective configuration modules.
+     *
+     * @param name the configuration property name to resolve
+     * @return the corresponding ConfigModule
+     * @throws IllegalArgumentException if the property name is not recognized
+     */
+    private ConfigModule resolve(String name) {
+        if (HOST.name().equals(name)) {
+            return HOST;
+        }
+        if (PORT.name().equals(name)) {
+            return PORT;
+        }
+        if (PASSWORD.name().equals(name)) {
+            return PASSWORD;
+        }
+        if (DATABASE.name().equals(name)) {
+            return DATABASE;
+        }
+        if (TIMEOUT.name().equals(name)) {
+            return TIMEOUT;
+        }
+        if (POOL_MAX_TOTAL.name().equals(name)) {
+            return POOL_MAX_TOTAL;
+        }
+        if (POOL_MAX_IDLE.name().equals(name)) {
+            return POOL_MAX_IDLE;
+        }
+        if (POOL_MIN_IDLE.name().equals(name)) {
+            return POOL_MIN_IDLE;
+        }
+        if (POOL_TEST_ON_BORROW.name().equals(name)) {
+            return POOL_TEST_ON_BORROW;
+        }
+        if (POOL_TEST_ON_RETURN.name().equals(name)) {
+            return POOL_TEST_ON_RETURN;
+        }
+        if (POOL_TEST_WHILE_IDLE.name().equals(name)) {
+            return POOL_TEST_WHILE_IDLE;
+        }
+        if (POOL_MAX_WAIT_MILLIS.name().equals(name)) {
+            return POOL_MAX_WAIT_MILLIS;
+        }
+
+        throw new IllegalArgumentException("Unknown Redis configuration property: " + name
+                + ". Supported properties: redis.host, redis.port, redis.password, redis.database, redis.timeout, "
+                + "redis.pool.max-total, redis.pool.max-idle, redis.pool.min-idle, redis.pool.test-on-borrow, "
+                + "redis.pool.test-on-return, redis.pool.test-while-idle, redis.pool.max-wait-millis");
+    }
+
+    /**
+     * Returns the unique name identifier for this Redis memory configuration module.
+     *
+     * <p>This name is used to identify the module and corresponds to the expected
+     * properties file name ({@code forage-memory-redis.properties}).
+     *
+     * @return the module name "forage-memory-redis"
+     */
+    @Override
+    public String name() {
+        return "forage-memory-redis";
+    }
+
+    /**
+     * Registers a configuration property value that was loaded from a configuration file.
+     *
+     * <p>This method is called by the configuration loading system to dynamically
+     * register properties that were found in the module's properties file or other
+     * external configuration sources.
+     *
+     * @param name the configuration property name (e.g., "redis.host", "redis.port")
+     * @param value the configuration property value
+     * @throws IllegalArgumentException if the property name is not recognized by this module
+     */
+    @Override
+    public void register(String name, String value) {
+        ConfigModule config = resolve(name);
+        ConfigStore.getInstance().set(config, value);
+    }
+}

--- a/library/ai/chat-memory/forage-memory-redis/src/main/java/org/apache/camel/forage/memory/chat/redis/RedisMemoryFactory.java
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/java/org/apache/camel/forage/memory/chat/redis/RedisMemoryFactory.java
@@ -1,0 +1,160 @@
+package org.apache.camel.forage.memory.chat.redis;
+
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import org.apache.camel.forage.core.ai.ChatMemoryFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.exceptions.JedisException;
+
+/**
+ * Redis-based implementation of {@link ChatMemoryFactory} that creates chat memory providers
+ * with persistent storage using Redis as the backing store.
+ *
+ * <p>This factory creates {@link ChatMemoryProvider} instances that use Redis for storing
+ * conversation history, enabling chat memory to persist across application restarts and
+ * be shared across multiple application instances.
+ *
+ * <p><strong>Key Features:</strong>
+ * <ul>
+ *   <li>Persistent chat memory storage using Redis</li>
+ *   <li>Configurable message window size for memory management</li>
+ *   <li>Connection pooling for optimal Redis performance</li>
+ *   <li>Automatic discovery via ServiceLoader mechanism</li>
+ *   <li>Thread-safe memory provider creation</li>
+ * </ul>
+ *
+ * <p><strong>Configuration:</strong>
+ * The factory uses {@link RedisConfig} to obtain Redis connection parameters.
+ * Configuration can be provided through environment variables, system properties,
+ * or configuration files. See {@link RedisConfig} for detailed configuration options.
+ *
+ * <p><strong>Thread Safety:</strong>
+ * This factory is thread-safe and can be safely used in concurrent environments.
+ * Each call to {@link #newChatMemory()} returns a provider that can handle multiple
+ * concurrent memory operations.
+ *
+ * @see ChatMemoryFactory
+ * @see RedisConfig
+ * @see PersistentRedisStore
+ * @since 1.0
+ */
+public class RedisMemoryFactory implements ChatMemoryFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(RedisMemoryFactory.class);
+    private static final int DEFAULT_MAX_MESSAGES = 100;
+
+    private static final RedisConfig CONFIG = new RedisConfig();
+    private static final JedisPool JEDIS_POOL;
+    private static final PersistentRedisStore REDIS_STORE;
+
+    static {
+        LOG.info(
+                "Initializing Redis chat memory provider with host: {}, port: {}, database: {}",
+                CONFIG.host(),
+                CONFIG.port(),
+                CONFIG.database());
+
+        try {
+            // Initialize Redis connection pool with configuration from RedisConfig
+            JedisPoolConfig poolConfig = new JedisPoolConfig();
+            poolConfig.setMaxTotal(CONFIG.poolMaxTotal());
+            poolConfig.setMaxIdle(CONFIG.poolMaxIdle());
+            poolConfig.setMinIdle(CONFIG.poolMinIdle());
+            poolConfig.setTestOnBorrow(CONFIG.poolTestOnBorrow());
+            poolConfig.setTestOnReturn(CONFIG.poolTestOnReturn());
+            poolConfig.setTestWhileIdle(CONFIG.poolTestWhileIdle());
+            poolConfig.setMaxWaitMillis(CONFIG.poolMaxWaitMillis());
+
+            LOG.debug(
+                    "Redis pool configuration: maxTotal={}, maxIdle={}, minIdle={}, testOnBorrow={}, testOnReturn={}, testWhileIdle={}, maxWaitMillis={}",
+                    poolConfig.getMaxTotal(),
+                    poolConfig.getMaxIdle(),
+                    poolConfig.getMinIdle(),
+                    poolConfig.getTestOnBorrow(),
+                    poolConfig.getTestOnReturn(),
+                    poolConfig.getTestWhileIdle(),
+                    poolConfig.getMaxWaitMillis());
+
+            JEDIS_POOL = new JedisPool(
+                    poolConfig, CONFIG.host(), CONFIG.port(), CONFIG.timeout(), CONFIG.password(), CONFIG.database());
+
+            // Test the connection
+            try (var jedis = JEDIS_POOL.getResource()) {
+                jedis.ping();
+                LOG.info(
+                        "Successfully connected to Redis at {}:{}/{} with pool configuration",
+                        CONFIG.host(),
+                        CONFIG.port(),
+                        CONFIG.database());
+            }
+
+            REDIS_STORE = new PersistentRedisStore(JEDIS_POOL);
+
+        } catch (JedisException e) {
+            LOG.error("Failed to initialize Redis connection pool for chat memory", e);
+            throw new RuntimeException("Failed to connect to Redis for chat memory storage", e);
+        }
+    }
+
+    /**
+     * Creates a new Redis memory factory.
+     *
+     * <p>The factory uses the statically initialized Redis connection pool that was
+     * configured during class loading using the {@link RedisConfig} settings.
+     */
+    public RedisMemoryFactory() {
+        // Redis pool and store are initialized statically
+    }
+
+    /**
+     * Creates a new chat memory provider that uses Redis for persistent storage.
+     *
+     * <p>This method returns a {@link ChatMemoryProvider} that creates message window-based
+     * chat memory instances backed by Redis storage. Each memory instance can store up to
+     * the configured maximum number of messages per conversation.
+     *
+     * <p>The returned provider is thread-safe and can be used to create multiple chat
+     * memory instances for different conversations. All instances will share the same
+     * Redis connection pool for optimal performance.
+     *
+     * <p><strong>Memory Lifecycle:</strong>
+     * The chat memories created by the returned provider will automatically persist
+     * messages to Redis and retrieve them on subsequent access. The message window
+     * will automatically manage the conversation size by removing oldest messages
+     * when the maximum is exceeded.
+     *
+     * @return a new chat memory provider backed by Redis storage, never {@code null}
+     * @throws RuntimeException if Redis connection cannot be established or configured
+     */
+    @Override
+    public ChatMemoryProvider newChatMemory() {
+        return memoryId -> {
+            LOG.debug("Creating message window chat memory for ID: {}", memoryId);
+            return MessageWindowChatMemory.builder()
+                    .id(memoryId)
+                    .maxMessages(DEFAULT_MAX_MESSAGES)
+                    .chatMemoryStore(REDIS_STORE)
+                    .build();
+        };
+    }
+
+    /**
+     * Closes the Redis connection pool and releases all associated resources.
+     *
+     * <p>This method should be called during application shutdown to ensure proper
+     * cleanup of Redis connections. After calling this method, the factory should
+     * not be used to create new memory providers.
+     *
+     * <p><strong>Note:</strong> This method is not automatically called and must be
+     * explicitly invoked by the application or container during shutdown. Since the
+     * Redis pool is static, this affects all instances of this factory class.
+     */
+    public static void close() {
+        if (JEDIS_POOL != null && !JEDIS_POOL.isClosed()) {
+            LOG.info("Closing Redis connection pool for chat memory");
+            JEDIS_POOL.close();
+        }
+    }
+}

--- a/library/ai/chat-memory/forage-memory-redis/src/main/resources/META-INF/services/org.apache.camel.forage.core.ai.ChatMemoryFactory
+++ b/library/ai/chat-memory/forage-memory-redis/src/main/resources/META-INF/services/org.apache.camel.forage.core.ai.ChatMemoryFactory
@@ -1,0 +1,1 @@
+org.apache.camel.forage.memory.chat.redis.RedisMemoryFactory

--- a/library/ai/chat-memory/pom.xml
+++ b/library/ai/chat-memory/pom.xml
@@ -16,6 +16,7 @@
 
     <modules>
         <module>forage-memory-message-window</module>
+        <module>forage-memory-redis</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Example of usage:

- run redis with `camel infra run redis`
- create a `forage-memory-redis.properties` file with the following content
```
redis.host=$JSON_OUTPUT_FROM_CAMEL_INFRA_REDIS_RUN
redis.port=$JSON_OUTPUT_FROM_CAMEL_INFRA_REDIS_RUN
```
- Add the following dependency `--dep=mvn:org.apache.camel.forage:forage-memory-redis:1.0-SNAPSHOT` to the camel app