### PR TITLE
Forage Memory Infinispan

### DIFF
--- a/core/forage-core-common/src/main/java/org/apache/camel/forage/core/util/config/ConfigEntry.java
+++ b/core/forage-core-common/src/main/java/org/apache/camel/forage/core/util/config/ConfigEntry.java
@@ -85,6 +85,16 @@ public class ConfigEntry {
         return new ConfigEntry(envName, envName.replace("_", ".").toLowerCase());
     }
 
+    public static ConfigEntry fromModule(ConfigModule module, String envName) {
+        Objects.requireNonNull(module, "module");
+
+        if (envName == null || envName.isEmpty()) {
+            envName = envName.replace(".", "_").toUpperCase();
+        }
+
+        return new ConfigEntry(envName, module.name());
+    }
+
     /**
      * Creates a ConfigEntry from a system property name.
      *

--- a/library/ai/chat-memory/forage-memory-infinispan/pom.xml
+++ b/library/ai/chat-memory/forage-memory-infinispan/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>chat-memory</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-memory-infinispan</artifactId>
+    <packaging>jar</packaging>
+    <name>Camel Forage :: Library :: AI :: Chat Memory :: Infinispan</name>
+
+    <properties>
+        <infinispan.version>15.2.5.Final</infinispan.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-ai</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-langchain4j-agent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+            <version>${infinispan.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/org/apache/camel/forage/memory/chat/infinispan/InfinispanConfig.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/org/apache/camel/forage/memory/chat/infinispan/InfinispanConfig.java
@@ -1,0 +1,385 @@
+package org.apache.camel.forage.memory.chat.infinispan;
+
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+
+/**
+ * Configuration class for Infinispan-based chat memory storage in the Camel Forage framework.
+ *
+ * <p>This configuration manages connection parameters for Infinispan clusters used to store
+ * persistent chat conversation history. It follows the standard Camel Forage configuration
+ * pattern with support for multiple configuration sources and environment-specific overrides.
+ *
+ * <p><strong>Configuration Properties:</strong>
+ * <ul>
+ *   <li><code>infinispan.server-list</code> - Comma-separated list of Infinispan servers (default: localhost:11222) - required</li>
+ *   <li><code>infinispan.cache-name</code> - Name of the cache for storing chat messages (default: chat-memory) - required</li>
+ *   <li><code>infinispan.username</code> - Username for authentication (optional)</li>
+ *   <li><code>infinispan.password</code> - Password for authentication (optional)</li>
+ *   <li><code>infinispan.realm</code> - Security realm (default: default)</li>
+ *   <li><code>infinispan.sasl-mechanism</code> - SASL mechanism for authentication (default: DIGEST-MD5)</li>
+ *   <li><code>infinispan.connection-timeout</code> - Connection timeout in milliseconds (default: 60000)</li>
+ *   <li><code>infinispan.socket-timeout</code> - Socket timeout in milliseconds (default: 60000)</li>
+ *   <li><code>infinispan.max-retries</code> - Maximum number of connection retries (default: 3)</li>
+ *   <li><code>infinispan.pool.max-active</code> - Maximum active connections per server (default: 20)</li>
+ *   <li><code>infinispan.pool.max-wait</code> - Maximum time to wait for connection in milliseconds (default: 3000)</li>
+ * </ul>
+ *
+ * <p><strong>Configuration Sources (in order of precedence):</strong>
+ * <ol>
+ *   <li>Environment variables: {@code INFINISPAN_SERVER_LIST}, {@code INFINISPAN_CACHE_NAME}, {@code INFINISPAN_USERNAME}, {@code INFINISPAN_POOL_MAX_ACTIVE}, etc.</li>
+ *   <li>System properties: {@code infinispan.server-list}, {@code infinispan.cache-name}, {@code infinispan.username}, etc.</li>
+ *   <li>Configuration file: {@code forage-memory-infinispan.properties}</li>
+ *   <li>Default values where applicable</li>
+ * </ol>
+ *
+ * <p><strong>Example Environment Configuration:</strong>
+ * <pre>{@code
+ * export INFINISPAN_SERVER_LIST=infinispan1.example.com:11222,infinispan2.example.com:11222
+ * export INFINISPAN_CACHE_NAME=chat-memory
+ * export INFINISPAN_USERNAME=admin
+ * export INFINISPAN_PASSWORD=secret123
+ * export INFINISPAN_CONNECTION_TIMEOUT=30000
+ * export INFINISPAN_POOL_MAX_ACTIVE=25
+ * }</pre>
+ *
+ * <p><strong>Example System Properties:</strong>
+ * <pre>{@code
+ * -Dinfinispan.server-list=infinispan1.example.com:11222,infinispan2.example.com:11222
+ * -Dinfinispan.cache-name=chat-memory
+ * -Dinfinispan.username=admin
+ * -Dinfinispan.password=secret123
+ * -Dinfinispan.connection-timeout=30000
+ * -Dinfinispan.pool.max-active=25
+ * }</pre>
+ *
+ * <p><strong>Example Properties File (forage-memory-infinispan.properties):</strong>
+ * <pre>
+ * infinispan.server-list=infinispan1.example.com:11222,infinispan2.example.com:11222
+ * infinispan.cache-name=chat-memory
+ * infinispan.username=admin
+ * infinispan.password=secret123
+ * infinispan.realm=default
+ * infinispan.sasl-mechanism=DIGEST-MD5
+ * infinispan.connection-timeout=30000
+ * infinispan.socket-timeout=30000
+ * infinispan.max-retries=5
+ * infinispan.pool.max-active=25
+ * infinispan.pool.min-idle=2
+ * infinispan.pool.max-wait=5000
+ * </pre>
+ *
+ * @see Config
+ * @see ConfigStore
+ * @see PersistentInfinispanStore
+ * @since 1.0
+ */
+public class InfinispanConfig implements Config {
+
+    private static final ConfigModule SERVER_LIST = ConfigModule.of(InfinispanConfig.class, "infinispan.server-list");
+    private static final ConfigModule CACHE_NAME = ConfigModule.of(InfinispanConfig.class, "infinispan.cache-name");
+    private static final ConfigModule USERNAME = ConfigModule.of(InfinispanConfig.class, "infinispan.username");
+    private static final ConfigModule PASSWORD = ConfigModule.of(InfinispanConfig.class, "infinispan.password");
+    private static final ConfigModule REALM = ConfigModule.of(InfinispanConfig.class, "infinispan.realm");
+    private static final ConfigModule SASL_MECHANISM =
+            ConfigModule.of(InfinispanConfig.class, "infinispan.sasl-mechanism");
+    private static final ConfigModule CONNECTION_TIMEOUT =
+            ConfigModule.of(InfinispanConfig.class, "infinispan.connection-timeout");
+    private static final ConfigModule SOCKET_TIMEOUT =
+            ConfigModule.of(InfinispanConfig.class, "infinispan.socket-timeout");
+    private static final ConfigModule MAX_RETRIES = ConfigModule.of(InfinispanConfig.class, "infinispan.max-retries");
+
+    // Pool configuration
+    private static final ConfigModule POOL_MAX_ACTIVE =
+            ConfigModule.of(InfinispanConfig.class, "infinispan.pool.max-active");
+    private static final ConfigModule POOL_MIN_IDLE =
+            ConfigModule.of(InfinispanConfig.class, "infinispan.pool.min-idle");
+    private static final ConfigModule POOL_MAX_WAIT =
+            ConfigModule.of(InfinispanConfig.class, "infinispan.pool.max-wait");
+
+    /**
+     * Creates a new Infinispan configuration instance and registers configuration entries
+     * with the central {@link ConfigStore}.
+     *
+     * <p>This constructor automatically registers all Infinispan configuration parameters
+     * and their corresponding environment variable mappings. It also sets up the
+     * configuration loader to process property files if they exist.
+     */
+    public InfinispanConfig() {
+        ConfigStore.getInstance().add(SERVER_LIST, ConfigEntry.fromModule(SERVER_LIST, "INFINISPAN_SERVER_LIST"));
+        ConfigStore.getInstance().add(CACHE_NAME, ConfigEntry.fromModule(CACHE_NAME, "INFINISPAN_CACHE_NAME"));
+        ConfigStore.getInstance().add(USERNAME, ConfigEntry.fromModule(USERNAME, "INFINISPAN_USERNAME"));
+        ConfigStore.getInstance().add(PASSWORD, ConfigEntry.fromModule(PASSWORD, "INFINISPAN_PASSWORD"));
+        ConfigStore.getInstance().add(REALM, ConfigEntry.fromModule(REALM, "INFINISPAN_REALM"));
+        ConfigStore.getInstance()
+                .add(SASL_MECHANISM, ConfigEntry.fromModule(SASL_MECHANISM, "INFINISPAN_SASL_MECHANISM"));
+        ConfigStore.getInstance()
+                .add(CONNECTION_TIMEOUT, ConfigEntry.fromModule(CONNECTION_TIMEOUT, "INFINISPAN_CONNECTION_TIMEOUT"));
+        ConfigStore.getInstance()
+                .add(SOCKET_TIMEOUT, ConfigEntry.fromModule(SOCKET_TIMEOUT, "INFINISPAN_SOCKET_TIMEOUT"));
+        ConfigStore.getInstance().add(MAX_RETRIES, ConfigEntry.fromModule(MAX_RETRIES, "INFINISPAN_MAX_RETRIES"));
+
+        // Pool configuration
+        ConfigStore.getInstance()
+                .add(POOL_MAX_ACTIVE, ConfigEntry.fromModule(POOL_MAX_ACTIVE, "INFINISPAN_POOL_MAX_ACTIVE"));
+        ConfigStore.getInstance().add(POOL_MIN_IDLE, ConfigEntry.fromModule(POOL_MIN_IDLE, "INFINISPAN_POOL_MIN_IDLE"));
+        ConfigStore.getInstance().add(POOL_MAX_WAIT, ConfigEntry.fromModule(POOL_MAX_WAIT, "INFINISPAN_POOL_MAX_WAIT"));
+
+        ConfigStore.getInstance().add(InfinispanConfig.class, this, this::register);
+    }
+
+    /**
+     * Returns the comma-separated list of Infinispan server addresses.
+     *
+     * @return the server list in format "host1:port1,host2:port2", defaults to "localhost:11222" if not configured
+     */
+    public String serverList() {
+        return ConfigStore.getInstance().get(SERVER_LIST).orElse("localhost:11222");
+    }
+
+    /**
+     * Returns the name of the Infinispan cache to use for storing chat messages.
+     *
+     * @return the cache name, defaults to "chat-memory" if not configured
+     */
+    public String cacheName() {
+        return ConfigStore.getInstance().get(CACHE_NAME).orElse("chat-memory");
+    }
+
+    /**
+     * Returns the username for Infinispan authentication.
+     *
+     * @return the username, or {@code null} if no authentication is required
+     */
+    public String username() {
+        return ConfigStore.getInstance().get(USERNAME).orElse(null);
+    }
+
+    /**
+     * Returns the password for Infinispan authentication.
+     *
+     * @return the password, or {@code null} if no authentication is required
+     */
+    public String password() {
+        return ConfigStore.getInstance().get(PASSWORD).orElse(null);
+    }
+
+    /**
+     * Returns the security realm for Infinispan authentication.
+     *
+     * @return the realm, defaults to "default" if not configured
+     */
+    public String realm() {
+        return ConfigStore.getInstance().get(REALM).orElse("default");
+    }
+
+    /**
+     * Returns the SASL mechanism for Infinispan authentication.
+     *
+     * @return the SASL mechanism, defaults to "DIGEST-MD5" if not configured
+     */
+    public String saslMechanism() {
+        return ConfigStore.getInstance().get(SASL_MECHANISM).orElse("DIGEST-MD5");
+    }
+
+    /**
+     * Returns the connection timeout in milliseconds.
+     *
+     * @return the connection timeout in milliseconds, defaults to 60000ms if not configured
+     * @throws IllegalArgumentException if the configured timeout value is not a valid integer
+     */
+    public int connectionTimeout() {
+        return ConfigStore.getInstance()
+                .get(CONNECTION_TIMEOUT)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Infinispan connection timeout value: " + value, e);
+                    }
+                })
+                .orElse(60000);
+    }
+
+    /**
+     * Returns the socket timeout in milliseconds.
+     *
+     * @return the socket timeout in milliseconds, defaults to 60000ms if not configured
+     * @throws IllegalArgumentException if the configured timeout value is not a valid integer
+     */
+    public int socketTimeout() {
+        return ConfigStore.getInstance()
+                .get(SOCKET_TIMEOUT)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Infinispan socket timeout value: " + value, e);
+                    }
+                })
+                .orElse(60000);
+    }
+
+    /**
+     * Returns the maximum number of connection retries.
+     *
+     * @return the maximum retries, defaults to 3 if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid integer
+     */
+    public int maxRetries() {
+        return ConfigStore.getInstance()
+                .get(MAX_RETRIES)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Infinispan max retries value: " + value, e);
+                    }
+                })
+                .orElse(3);
+    }
+
+    /**
+     * Returns the maximum number of active connections per server.
+     *
+     * @return the maximum active connections per server, defaults to 20 if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid integer
+     */
+    public int poolMaxActive() {
+        return ConfigStore.getInstance()
+                .get(POOL_MAX_ACTIVE)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Infinispan pool max-active value: " + value, e);
+                    }
+                })
+                .orElse(20);
+    }
+
+    /**
+     * Returns the minimum number of idle connections per server.
+     *
+     * @return the minimum idle connections per server, defaults to 1 if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid integer
+     */
+    public int poolMinIdle() {
+        return ConfigStore.getInstance()
+                .get(POOL_MIN_IDLE)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Infinispan pool min-idle value: " + value, e);
+                    }
+                })
+                .orElse(1);
+    }
+
+    /**
+     * Returns the maximum time to wait for a connection in milliseconds.
+     *
+     * @return the maximum wait time in milliseconds, defaults to 3000ms if not configured
+     * @throws IllegalArgumentException if the configured value is not a valid integer
+     */
+    public int poolMaxWait() {
+        return ConfigStore.getInstance()
+                .get(POOL_MAX_WAIT)
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid Infinispan pool max-wait value: " + value, e);
+                    }
+                })
+                .orElse(3000);
+    }
+
+    /**
+     * Resolves a configuration property name to its corresponding {@link ConfigModule}.
+     *
+     * <p>This method is used during configuration loading to map property names from
+     * configuration files to their respective configuration modules.
+     *
+     * @param name the configuration property name to resolve
+     * @return the corresponding ConfigModule
+     * @throws IllegalArgumentException if the property name is not recognized
+     */
+    private ConfigModule resolve(String name) {
+        if (SERVER_LIST.name().equals(name)) {
+            return SERVER_LIST;
+        }
+        if (CACHE_NAME.name().equals(name)) {
+            return CACHE_NAME;
+        }
+        if (USERNAME.name().equals(name)) {
+            return USERNAME;
+        }
+        if (PASSWORD.name().equals(name)) {
+            return PASSWORD;
+        }
+        if (REALM.name().equals(name)) {
+            return REALM;
+        }
+        if (SASL_MECHANISM.name().equals(name)) {
+            return SASL_MECHANISM;
+        }
+        if (CONNECTION_TIMEOUT.name().equals(name)) {
+            return CONNECTION_TIMEOUT;
+        }
+        if (SOCKET_TIMEOUT.name().equals(name)) {
+            return SOCKET_TIMEOUT;
+        }
+        if (MAX_RETRIES.name().equals(name)) {
+            return MAX_RETRIES;
+        }
+        if (POOL_MAX_ACTIVE.name().equals(name)) {
+            return POOL_MAX_ACTIVE;
+        }
+        if (POOL_MIN_IDLE.name().equals(name)) {
+            return POOL_MIN_IDLE;
+        }
+        if (POOL_MAX_WAIT.name().equals(name)) {
+            return POOL_MAX_WAIT;
+        }
+
+        throw new IllegalArgumentException("Unknown Infinispan configuration property: " + name
+                + ". Supported properties: infinispan.server-list, infinispan.cache-name, infinispan.username, "
+                + "infinispan.password, infinispan.realm, infinispan.sasl-mechanism, infinispan.connection-timeout, "
+                + "infinispan.socket-timeout, infinispan.max-retries, infinispan.pool.max-active, "
+                + "infinispan.pool.min-idle, infinispan.pool.max-wait");
+    }
+
+    /**
+     * Returns the unique name identifier for this Infinispan memory configuration module.
+     *
+     * <p>This name is used to identify the module and corresponds to the expected
+     * properties file name ({@code forage-memory-infinispan.properties}).
+     *
+     * @return the module name "forage-memory-infinispan"
+     */
+    @Override
+    public String name() {
+        return "forage-memory-infinispan";
+    }
+
+    /**
+     * Registers a configuration property value that was loaded from a configuration file.
+     *
+     * <p>This method is called by the configuration loading system to dynamically
+     * register properties that were found in the module's properties file or other
+     * external configuration sources.
+     *
+     * @param name the configuration property name (e.g., "infinispan.server-list", "infinispan.cache-name")
+     * @param value the configuration property value
+     * @throws IllegalArgumentException if the property name is not recognized by this module
+     */
+    @Override
+    public void register(String name, String value) {
+        ConfigModule config = resolve(name);
+        ConfigStore.getInstance().set(config, value);
+    }
+}

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/org/apache/camel/forage/memory/chat/infinispan/InfinispanMemoryFactory.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/org/apache/camel/forage/memory/chat/infinispan/InfinispanMemoryFactory.java
@@ -1,0 +1,185 @@
+package org.apache.camel.forage.memory.chat.infinispan;
+
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import org.apache.camel.forage.core.ai.ChatMemoryFactory;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Infinispan-based implementation of {@link ChatMemoryFactory} that creates chat memory providers
+ * with persistent storage using Infinispan as the backing store.
+ *
+ * <p>This factory creates {@link ChatMemoryProvider} instances that use Infinispan for storing
+ * conversation history, enabling chat memory to persist across application restarts and
+ * be shared across multiple application instances in a distributed environment.
+ *
+ * <p><strong>Key Features:</strong>
+ * <ul>
+ *   <li>Persistent chat memory storage using Infinispan</li>
+ *   <li>Configurable message window size for memory management</li>
+ *   <li>Distributed caching for scalability and high availability</li>
+ *   <li>Automatic discovery via ServiceLoader mechanism</li>
+ *   <li>Thread-safe memory provider creation</li>
+ * </ul>
+ *
+ * <p><strong>Configuration:</strong>
+ * The factory uses {@link InfinispanConfig} to obtain Infinispan connection parameters.
+ * Configuration can be provided through environment variables, system properties,
+ * or configuration files. See {@link InfinispanConfig} for detailed configuration options.
+ *
+ * <p><strong>Thread Safety:</strong>
+ * This factory is thread-safe and can be safely used in concurrent environments.
+ * Each call to {@link #newChatMemory()} returns a provider that can handle multiple
+ * concurrent memory operations.
+ *
+ * @see ChatMemoryFactory
+ * @see InfinispanConfig
+ * @see PersistentInfinispanStore
+ * @since 1.0
+ */
+public class InfinispanMemoryFactory implements ChatMemoryFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(InfinispanMemoryFactory.class);
+    private static final int DEFAULT_MAX_MESSAGES = 10;
+
+    private static final InfinispanConfig CONFIG = new InfinispanConfig();
+    private static final RemoteCacheManager CACHE_MANAGER;
+    private static RemoteCache<String, String> CACHE;
+    private static final PersistentInfinispanStore INFINISPAN_STORE;
+
+    static {
+        LOG.info(
+                "Initializing Infinispan chat memory provider with servers: {}, cache: {}",
+                CONFIG.serverList(),
+                CONFIG.cacheName());
+
+        try {
+            // Initialize Infinispan cache manager with configuration from InfinispanConfig
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.addServers(CONFIG.serverList());
+            builder.connectionTimeout(CONFIG.connectionTimeout());
+            builder.socketTimeout(CONFIG.socketTimeout());
+            builder.maxRetries(CONFIG.maxRetries());
+
+            // Configure connection pool settings
+            LOG.debug(
+                    "Configuring Infinispan connection pool: maxActive={}, maxIdle={}, maxTotal={}, minIdle={}, maxWait={}ms",
+                    CONFIG.poolMaxActive(),
+                    CONFIG.poolMinIdle(),
+                    CONFIG.poolMaxWait());
+            builder.connectionPool()
+                    .maxActive(CONFIG.poolMaxActive())
+                    .minIdle(CONFIG.poolMinIdle())
+                    .maxWait(CONFIG.poolMaxWait());
+
+            // Configure authentication if credentials are provided
+            if (CONFIG.username() != null && CONFIG.password() != null) {
+                LOG.debug("Configuring SASL authentication with mechanism: {}", CONFIG.saslMechanism());
+                builder.security()
+                        .authentication()
+                        .enable()
+                        .username(CONFIG.username())
+                        .password(CONFIG.password())
+                        .realm(CONFIG.realm())
+                        .saslMechanism(CONFIG.saslMechanism());
+            }
+
+            CACHE_MANAGER = new RemoteCacheManager(builder.build());
+
+            // Start the cache manager
+            CACHE_MANAGER.start();
+
+            // Get or create the cache for chat messages
+            String cacheName = CONFIG.cacheName();
+            try {
+                // Try to get the named cache first
+                CACHE = CACHE_MANAGER.getCache(cacheName);
+                if (CACHE == null) {
+                    LOG.info("Cache '{}' not found, creating it with default template", cacheName);
+                    // Create cache using the default template
+                    CACHE_MANAGER.administration().createCache(cacheName, (String) null);
+                    CACHE = CACHE_MANAGER.getCache(cacheName);
+                }
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        String.format("Failed to get or create named cache %s", cacheName), e);
+            }
+
+            // Test the connection by performing a simple operation
+            CACHE.size(); // This will throw an exception if connection fails
+            LOG.info(
+                    "Successfully connected to Infinispan cluster at {} with cache '{}'",
+                    CONFIG.serverList(),
+                    CONFIG.cacheName());
+
+            INFINISPAN_STORE = new PersistentInfinispanStore(CACHE);
+
+        } catch (Exception e) {
+            LOG.error("Failed to initialize Infinispan connection for chat memory", e);
+            throw new RuntimeException("Failed to connect to Infinispan for chat memory storage", e);
+        }
+    }
+
+    /**
+     * Creates a new Infinispan memory factory.
+     *
+     * <p>The factory uses the statically initialized Infinispan cache manager that was
+     * configured during class loading using the {@link InfinispanConfig} settings.
+     */
+    public InfinispanMemoryFactory() {
+        // Cache manager and store are initialized statically
+    }
+
+    /**
+     * Creates a new chat memory provider that uses Infinispan for persistent storage.
+     *
+     * <p>This method returns a {@link ChatMemoryProvider} that creates message window-based
+     * chat memory instances backed by Infinispan storage. Each memory instance can store up to
+     * the configured maximum number of messages per conversation.
+     *
+     * <p>The returned provider is thread-safe and can be used to create multiple chat
+     * memory instances for different conversations. All instances will share the same
+     * Infinispan cache for optimal performance and data consistency.
+     *
+     * <p><strong>Memory Lifecycle:</strong>
+     * The chat memories created by the returned provider will automatically persist
+     * messages to Infinispan and retrieve them on subsequent access. The message window
+     * will automatically manage the conversation size by removing oldest messages
+     * when the maximum is exceeded.
+     *
+     * @return a new chat memory provider backed by Infinispan storage, never {@code null}
+     * @throws RuntimeException if Infinispan connection cannot be established or configured
+     */
+    @Override
+    public ChatMemoryProvider newChatMemory() {
+        return memoryId -> {
+            LOG.debug("Creating message window chat memory for ID: {}", memoryId);
+            return MessageWindowChatMemory.builder()
+                    .id(memoryId)
+                    .maxMessages(DEFAULT_MAX_MESSAGES)
+                    .chatMemoryStore(INFINISPAN_STORE)
+                    .build();
+        };
+    }
+
+    /**
+     * Closes the Infinispan cache manager and releases all associated resources.
+     *
+     * <p>This method should be called during application shutdown to ensure proper
+     * cleanup of Infinispan connections. After calling this method, the factory should
+     * not be used to create new memory providers.
+     *
+     * <p><strong>Note:</strong> This method is not automatically called and must be
+     * explicitly invoked by the application or container during shutdown. Since the
+     * cache manager is static, this affects all instances of this factory class.
+     */
+    public static void close() {
+        if (CACHE_MANAGER != null) {
+            LOG.info("Closing Infinispan cache manager for chat memory");
+            CACHE_MANAGER.close();
+        }
+    }
+}

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/java/org/apache/camel/forage/memory/chat/infinispan/PersistentInfinispanStore.java
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/java/org/apache/camel/forage/memory/chat/infinispan/PersistentInfinispanStore.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.forage.memory.chat.infinispan;
+
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Infinispan-based implementation of {@link ChatMemoryStore} that provides persistent storage
+ * for chat conversation history using Infinispan as the backing store.
+ *
+ * <p>This implementation stores chat messages as JSON-serialized data in Infinispan, with each
+ * conversation identified by a unique memory ID. The store supports the full lifecycle
+ * of chat memory operations including retrieval, updates, and deletion.
+ *
+ * <p><strong>Key Features:</strong>
+ * <ul>
+ *   <li>Persistent storage of chat conversations across application restarts</li>
+ *   <li>Automatic JSON serialization/deserialization of chat messages</li>
+ *   <li>Distributed caching via Infinispan for scalability and high availability</li>
+ *   <li>UTF-8 encoding for proper international character support</li>
+ *   <li>Robust error handling with proper resource cleanup</li>
+ * </ul>
+ *
+ * <p><strong>Infinispan Key Structure:</strong>
+ * Each conversation is stored with the memory ID as the cache key, containing a JSON string
+ * of serialized {@link ChatMessage} objects. Empty conversations are represented as empty lists.
+ *
+ * <p><strong>Thread Safety:</strong>
+ * This class is thread-safe as it uses Infinispan's thread-safe {@link RemoteCache} operations.
+ * Multiple threads can safely access different conversations concurrently.
+ *
+ * <p><strong>Error Handling:</strong>
+ * Infinispan connection failures and serialization errors are properly handled and logged.
+ * Failed operations will not leave the cache in an inconsistent state.
+ *
+ * @see ChatMemoryStore
+ * @see RemoteCacheManager
+ * @since 1.0
+ */
+public class PersistentInfinispanStore implements ChatMemoryStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PersistentInfinispanStore.class);
+    private static final String EMPTY_MESSAGES_JSON = "[]";
+
+    private final RemoteCache<String, String> cache;
+
+    /**
+     * Creates a new Infinispan-based chat memory store.
+     *
+     * @param cache the Infinispan remote cache to use for storing chat messages, must not be {@code null}
+     * @throws NullPointerException if cache is null
+     */
+    public PersistentInfinispanStore(RemoteCache<String, String> cache) {
+        this.cache = Objects.requireNonNull(cache, "RemoteCache cannot be null");
+    }
+
+    /**
+     * Deletes all chat messages for the specified memory ID.
+     *
+     * <p>This operation removes the entire conversation history from Infinispan.
+     * If the memory ID does not exist, this operation is idempotent and will
+     * not raise an error.
+     *
+     * @param memoryId the unique identifier for the conversation to delete, must not be {@code null}
+     * @throws NullPointerException if memoryId is null
+     * @throws RuntimeException if an Infinispan operation fails
+     */
+    @Override
+    public void deleteMessages(Object memoryId) {
+        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+
+        String key = memoryId.toString();
+        try {
+            String removed = cache.remove(key);
+            if (removed != null) {
+                LOG.debug("Deleted conversation for memory ID: {}", key);
+            } else {
+                LOG.debug("No conversation found to delete for memory ID: {}", key);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to delete messages for memory ID: {}", key, e);
+            throw new RuntimeException("Failed to delete chat messages from Infinispan", e);
+        }
+    }
+
+    /**
+     * Retrieves all chat messages for the specified memory ID.
+     *
+     * <p>Returns the complete conversation history as a list of {@link ChatMessage} objects.
+     * If no conversation exists for the given memory ID, an empty list is returned.
+     *
+     * @param memoryId the unique identifier for the conversation to retrieve, must not be {@code null}
+     * @return a list of chat messages for the conversation, never {@code null} but may be empty
+     * @throws NullPointerException if memoryId is null
+     * @throws RuntimeException if an Infinispan operation or deserialization fails
+     */
+    @Override
+    public List<ChatMessage> getMessages(Object memoryId) {
+        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+
+        String key = memoryId.toString();
+        try {
+            String json = cache.get(key);
+
+            if (json == null) {
+                LOG.debug("No messages found for memory ID: {}", key);
+                return Collections.emptyList();
+            }
+
+            if (json.isEmpty() || EMPTY_MESSAGES_JSON.equals(json)) {
+                return Collections.emptyList();
+            }
+
+            List<ChatMessage> messages = ChatMessageDeserializer.messagesFromJson(json);
+            LOG.debug("Retrieved {} messages for memory ID: {}", messages.size(), key);
+            return messages;
+        } catch (Exception e) {
+            LOG.error("Failed to retrieve messages for memory ID: {}", key, e);
+            if (e.getMessage() != null && e.getMessage().contains("deserialization")) {
+                throw new RuntimeException("Failed to deserialize chat messages", e);
+            }
+            throw new RuntimeException("Failed to retrieve chat messages from Infinispan", e);
+        }
+    }
+
+    /**
+     * Updates the chat messages for the specified memory ID.
+     *
+     * <p>This operation replaces the entire conversation history with the provided messages.
+     * The messages are serialized to JSON format and stored in Infinispan. If the messages list
+     * is empty, an empty conversation is stored (not deleted).
+     *
+     * @param memoryId the unique identifier for the conversation to update, must not be {@code null}
+     * @param messages the complete list of messages for the conversation, must not be {@code null}
+     * @throws NullPointerException if memoryId or messages is null
+     * @throws RuntimeException if an Infinispan operation or serialization fails
+     */
+    @Override
+    public void updateMessages(Object memoryId, List<ChatMessage> messages) {
+        Objects.requireNonNull(memoryId, "Memory ID cannot be null");
+        Objects.requireNonNull(messages, "Messages list cannot be null");
+
+        String key = memoryId.toString();
+        try {
+            String json = ChatMessageSerializer.messagesToJson(messages);
+            cache.put(key, json);
+            LOG.debug("Updated {} messages for memory ID: {}", messages.size(), key);
+        } catch (Exception e) {
+            LOG.error("Failed to update messages for memory ID: {}", key, e);
+            if (e.getMessage() != null && e.getMessage().contains("serialization")) {
+                throw new RuntimeException("Failed to serialize chat messages", e);
+            }
+            throw new RuntimeException("Failed to update chat messages in Infinispan", e);
+        }
+    }
+}

--- a/library/ai/chat-memory/forage-memory-infinispan/src/main/resources/META-INF/services/org.apache.camel.forage.core.ai.ChatMemoryFactory
+++ b/library/ai/chat-memory/forage-memory-infinispan/src/main/resources/META-INF/services/org.apache.camel.forage.core.ai.ChatMemoryFactory
@@ -1,0 +1,1 @@
+org.apache.camel.forage.memory.chat.infinispan.InfinispanMemoryFactory

--- a/library/ai/chat-memory/pom.xml
+++ b/library/ai/chat-memory/pom.xml
@@ -17,6 +17,7 @@
     <modules>
         <module>forage-memory-message-window</module>
         <module>forage-memory-redis</module>
+        <module>forage-memory-infinispan</module>
         <module>tests</module>
     </modules>
 

--- a/library/ai/chat-memory/tests/forage-memory-tests-tck/pom.xml
+++ b/library/ai/chat-memory/tests/forage-memory-tests-tck/pom.xml
@@ -52,7 +52,14 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Testcontainers for Redis testing -->
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-memory-infinispan</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers for Redis and Infinispan testing -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/library/ai/chat-memory/tests/forage-memory-tests-tck/src/test/java/org/apache/camel/forage/memory/chat/tck/InfinispanMemoryTCKTest.java
+++ b/library/ai/chat-memory/tests/forage-memory-tests-tck/src/test/java/org/apache/camel/forage/memory/chat/tck/InfinispanMemoryTCKTest.java
@@ -1,0 +1,94 @@
+package org.apache.camel.forage.memory.chat.tck;
+
+import org.apache.camel.forage.core.ai.ChatMemoryFactory;
+import org.apache.camel.forage.memory.chat.infinispan.InfinispanMemoryFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Test for InfinispanMemoryFactory using the ChatMemoryFactoryTCK with testcontainers.
+ *
+ * <p>This test validates the InfinispanMemoryFactory implementation from the forage-memory-infinispan
+ * module against the comprehensive test suite provided by the TCK. It uses testcontainers
+ * to start a real Infinispan instance for testing.
+ *
+ * <p>The test ensures that the Infinispan-based chat memory implementation correctly handles:
+ * <ul>
+ *   <li>Message persistence across Infinispan operations</li>
+ *   <li>Memory isolation between different conversation IDs</li>
+ *   <li>Connection management and error handling</li>
+ *   <li>All standard chat memory operations</li>
+ *   <li>Distributed caching capabilities</li>
+ * </ul>
+ *
+ * @since 1.0
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class InfinispanMemoryTCKTest extends ChatMemoryFactoryTCK {
+
+    private static final int INFINISPAN_PORT = 11222;
+
+    @Container
+    static GenericContainer<?> infinispan = new GenericContainer<>(DockerImageName.parse("infinispan/server:15.1"))
+            .withExposedPorts(INFINISPAN_PORT)
+            .withEnv("USER", "admin")
+            .withEnv("PASS", "password");
+
+    @BeforeAll
+    static void setUpInfinispan() {
+        // Configure Infinispan connection for the test
+        String infinispanHost = infinispan.getHost();
+        Integer infinispanPort = infinispan.getMappedPort(INFINISPAN_PORT);
+
+        // Set system properties for Infinispan configuration
+        System.setProperty("infinispan.server-list", infinispanHost + ":" + infinispanPort);
+        System.setProperty("infinispan.cache-name", "chat-memory");
+        System.setProperty("infinispan.username", "admin");
+        System.setProperty("infinispan.password", "password");
+        System.setProperty("infinispan.realm", "default");
+        System.setProperty("infinispan.sasl-mechanism", "DIGEST-MD5");
+        System.setProperty("infinispan.connection-timeout", "60000");
+        System.setProperty("infinispan.socket-timeout", "60000");
+        System.setProperty("infinispan.max-retries", "3");
+    }
+
+    @AfterAll
+    static void tearDownInfinispan() {
+        // Clean up Infinispan configuration
+        System.clearProperty("infinispan.server-list");
+        System.clearProperty("infinispan.cache-name");
+        System.clearProperty("infinispan.username");
+        System.clearProperty("infinispan.password");
+        System.clearProperty("infinispan.realm");
+        System.clearProperty("infinispan.sasl-mechanism");
+        System.clearProperty("infinispan.connection-timeout");
+        System.clearProperty("infinispan.socket-timeout");
+        System.clearProperty("infinispan.max-retries");
+
+        // Close Infinispan cache manager
+        InfinispanMemoryFactory.close();
+    }
+
+    @Override
+    protected ChatMemoryFactory createChatMemoryFactory() {
+        return new InfinispanMemoryFactory();
+    }
+
+    @Test
+    void demonstratesInfinispanTCKUsage() {
+        // This test exists to demonstrate that the TCK is working with Infinispan
+        // All actual tests are inherited from ChatMemoryFactoryTCK
+    }
+
+    @Test
+    void infinispanContainerIsRunning() {
+        // Verify that the Infinispan container is properly started
+        assert infinispan.isRunning();
+        assert infinispan.getMappedPort(INFINISPAN_PORT) != null;
+    }
+}


### PR DESCRIPTION
@orpiske, while testing I noticed that with a ConfigModule like `ConfigModule.of(InfinispanConfig.class, "infinispan.server-list")` and a `ConfigStore.getInstance().add(SERVER_LIST, ConfigEntry.fromEnv("INFINISPAN_SERVER_LIST"));` when the env variable `INFINISPAN_SERVER_LIST` is converted to a ConfigEntry, the resulting system property is `infinispan.server.list` instead of the expected `infinispan.server-list` defined earlier.

This is why I created https://github.com/megacamelus/camel-forage/compare/main...Croway:memory-infinispan?expand=1#diff-78894a4d88bd05701213bb05e1c8aa0b9267b637acda7b92dce673e061eb74cbR88 but, if you can think of a more elegant way, let me know, in case I'll update all the ConfigEntry access.