### PR TITLE
Add provider.create to FileConfigTests, resolve difference between ConfigEntries and test properties files

### DIFF
--- a/library/ai/vector-dbs/forage-vectordb-chroma/src/test/java/org/apache/camel/forage/vectordb/chroma/ChromaFileConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-chroma/src/test/java/org/apache/camel/forage/vectordb/chroma/ChromaFileConfigTest.java
@@ -2,6 +2,8 @@ package org.apache.camel.forage.vectordb.chroma;
 
 import static org.assertj.core.api.Fail.fail;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +39,7 @@ public class ChromaFileConfigTest {
     private static void copyPropertiesFile() {
         try {
             Path sourceFile = Paths.get("test-configuration", PROPERTIES_FILE);
-            Path targetDir = Paths.get("src/test/resources");
+            Path targetDir = Paths.get(".");
             Path targetFile = targetDir.resolve(PROPERTIES_FILE);
 
             Files.createDirectories(targetDir);
@@ -58,7 +60,7 @@ public class ChromaFileConfigTest {
 
     private static void removePropertiesFile() {
         try {
-            Path targetFile = Paths.get("src/test/resources/" + PROPERTIES_FILE);
+            Path targetFile = Paths.get(".", PROPERTIES_FILE);
             if (Files.exists(targetFile)) {
                 Files.delete(targetFile);
                 LOG.info("Removed properties file: {}", targetFile);
@@ -88,7 +90,15 @@ public class ChromaFileConfigTest {
     public void shouldCreateChromaProviderInstance() {
         LOG.info("Testing Chroma provider instantiation");
         ChromaProvider provider = new ChromaProvider();
+        try {
+            EmbeddingStore<TextSegment> chroma = provider.create();
+        } catch (RuntimeException re) {
+            LOG.info("Expected a runtime exception on connecting to chroma, caught it successfully");
+        } catch (Exception e) {
+            fail("Could not instantiate a Chroma EmbeddingStore {}", e);
+        }
         org.assertj.core.api.Assertions.assertThat(provider).isNotNull();
+
         LOG.info("Successfully created Chroma provider");
     }
 }

--- a/library/ai/vector-dbs/forage-vectordb-chroma/test-configuration/forage-vectordb-chroma.properties
+++ b/library/ai/vector-dbs/forage-vectordb-chroma/test-configuration/forage-vectordb-chroma.properties
@@ -4,7 +4,7 @@
 
 # Connection settings
 chroma.url=http://localhost:8000
-chroma.collection-name=test_collection_from_file
+chroma.collection.name=test_collection_from_file
 
 # Request timeout in seconds (default: 5)
 chroma.timeout=30

--- a/library/ai/vector-dbs/forage-vectordb-infinispan/src/test/java/org/apache/camel/forage/vectordb/infinispan/InfinispanFileConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-infinispan/src/test/java/org/apache/camel/forage/vectordb/infinispan/InfinispanFileConfigTest.java
@@ -2,6 +2,8 @@ package org.apache.camel.forage.vectordb.infinispan;
 
 import static org.assertj.core.api.Fail.fail;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +39,7 @@ public class InfinispanFileConfigTest {
     private static void copyPropertiesFile() {
         try {
             Path sourceFile = Paths.get("test-configuration", PROPERTIES_FILE);
-            Path targetDir = Paths.get("src/test/resources");
+            Path targetDir = Paths.get(".");
             Path targetFile = targetDir.resolve(PROPERTIES_FILE);
 
             Files.createDirectories(targetDir);
@@ -58,7 +60,7 @@ public class InfinispanFileConfigTest {
 
     private static void removePropertiesFile() {
         try {
-            Path targetFile = Paths.get("src/test/resources/" + PROPERTIES_FILE);
+            Path targetFile = Paths.get(".", PROPERTIES_FILE);
             if (Files.exists(targetFile)) {
                 Files.delete(targetFile);
                 LOG.info("Removed properties file: {}", targetFile);
@@ -108,6 +110,13 @@ public class InfinispanFileConfigTest {
     public void shouldCreateInfinispanProviderInstance() {
         LOG.info("Testing Infinispan provider instantiation");
         InfinispanProvider provider = new InfinispanProvider();
+        try {
+            EmbeddingStore<TextSegment> inf = provider.create();
+        } catch (org.infinispan.client.hotrod.exceptions.TransportException te) {
+            LOG.info("Expected to catch TransportException, did successfully");
+        } catch (Exception e) {
+            fail("Caught exception trying to create Infinispan Embedding Store {}", e);
+        }
         org.assertj.core.api.Assertions.assertThat(provider).isNotNull();
         LOG.info("Successfully created Infinispan provider");
     }

--- a/library/ai/vector-dbs/forage-vectordb-infinispan/test-configuration/forage-vectordb-infinispan.properties
+++ b/library/ai/vector-dbs/forage-vectordb-infinispan/test-configuration/forage-vectordb-infinispan.properties
@@ -8,7 +8,7 @@ infinispan.username=admin
 infinispan.password=admin
 
 # Cache configuration
-infinispan.cache-name=test_cache_from_file
+infinispan.cache.name=test_cache_from_file
 infinispan.dimension=384
 infinispan.distance=3
 infinispan.similarity=COSINE

--- a/library/ai/vector-dbs/forage-vectordb-milvus/src/test/java/org/apache/camel/forage/vectordb/milvus/MilvusFileConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-milvus/src/test/java/org/apache/camel/forage/vectordb/milvus/MilvusFileConfigTest.java
@@ -2,6 +2,8 @@ package org.apache.camel.forage.vectordb.milvus;
 
 import static org.assertj.core.api.Fail.fail;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +39,7 @@ public class MilvusFileConfigTest {
     private static void copyPropertiesFile() {
         try {
             Path sourceFile = Paths.get("test-configuration", PROPERTIES_FILE);
-            Path targetDir = Paths.get("src/test/resources");
+            Path targetDir = Paths.get(".");
             Path targetFile = targetDir.resolve(PROPERTIES_FILE);
 
             Files.createDirectories(targetDir);
@@ -58,7 +60,7 @@ public class MilvusFileConfigTest {
 
     private static void removePropertiesFile() {
         try {
-            Path targetFile = Paths.get("src/test/resources/" + PROPERTIES_FILE);
+            Path targetFile = Paths.get(".", PROPERTIES_FILE);
             if (Files.exists(targetFile)) {
                 Files.delete(targetFile);
                 LOG.info("Removed properties file: {}", targetFile);
@@ -115,6 +117,13 @@ public class MilvusFileConfigTest {
         LOG.info("Testing Milvus provider instantiation");
         MilvusProvider provider = new MilvusProvider();
         org.assertj.core.api.Assertions.assertThat(provider).isNotNull();
+        try {
+            EmbeddingStore<TextSegment> milv = provider.create();
+        } catch (RuntimeException re) {
+            LOG.info("Expected to catch RuntimeException creating Milvus Embedding Store and did succesfully...");
+        } catch (Exception e) {
+            fail("Caught exception trying to create Milvus Embedding Store {}", e);
+        }
         LOG.info("Successfully created Milvus provider");
     }
 }

--- a/library/ai/vector-dbs/forage-vectordb-pgvector/src/test/java/org/apache/camel/forage/vectordb/pgvector/PgVectorFileConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-pgvector/src/test/java/org/apache/camel/forage/vectordb/pgvector/PgVectorFileConfigTest.java
@@ -2,6 +2,8 @@ package org.apache.camel.forage.vectordb.pgvector;
 
 import static org.assertj.core.api.Fail.fail;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +39,7 @@ public class PgVectorFileConfigTest {
     private static void copyPropertiesFile() {
         try {
             Path sourceFile = Paths.get("test-configuration", PROPERTIES_FILE);
-            Path targetDir = Paths.get("src/test/resources");
+            Path targetDir = Paths.get(".");
             Path targetFile = targetDir.resolve(PROPERTIES_FILE);
 
             Files.createDirectories(targetDir);
@@ -58,7 +60,7 @@ public class PgVectorFileConfigTest {
 
     private static void removePropertiesFile() {
         try {
-            Path targetFile = Paths.get("src/test/resources/" + PROPERTIES_FILE);
+            Path targetFile = Paths.get(".", PROPERTIES_FILE);
             if (Files.exists(targetFile)) {
                 Files.delete(targetFile);
                 LOG.info("Removed properties file: {}", targetFile);
@@ -102,6 +104,13 @@ public class PgVectorFileConfigTest {
     public void shouldCreatePgVectorProviderInstance() {
         LOG.info("Testing PgVector provider instantiation");
         PgVectorProvider provider = new PgVectorProvider();
+        try {
+            EmbeddingStore<TextSegment> pgvect = provider.create();
+        } catch (RuntimeException re) {
+            LOG.info("Succesfully caught RuntimeException when creating PGVector embedding store");
+        } catch (Exception e) {
+            fail("Caught exception trying to create PGVector embedding store {}", e);
+        }
         org.assertj.core.api.Assertions.assertThat(provider).isNotNull();
         LOG.info("Successfully created PgVector provider");
     }

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/src/test/java/org/apache/camel/forage/vectordb/pinecone/PineconeFileConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/src/test/java/org/apache/camel/forage/vectordb/pinecone/PineconeFileConfigTest.java
@@ -2,6 +2,8 @@ package org.apache.camel.forage.vectordb.pinecone;
 
 import static org.assertj.core.api.Fail.fail;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,7 +42,7 @@ public class PineconeFileConfigTest {
     private static void copyPropertiesFile() {
         try {
             Path sourceFile = Paths.get("test-configuration", PROPERTIES_FILE);
-            Path targetDir = Paths.get("src/test/resources");
+            Path targetDir = Paths.get(".");
             Path targetFile = targetDir.resolve(PROPERTIES_FILE);
 
             Files.createDirectories(targetDir);
@@ -61,7 +63,7 @@ public class PineconeFileConfigTest {
 
     private static void removePropertiesFile() {
         try {
-            Path targetFile = Paths.get("src/test/resources/" + PROPERTIES_FILE);
+            Path targetFile = Paths.get(".", PROPERTIES_FILE);
             if (Files.exists(targetFile)) {
                 Files.delete(targetFile);
                 LOG.info("Removed properties file: {}", targetFile);
@@ -104,6 +106,15 @@ public class PineconeFileConfigTest {
         LOG.info("Testing Pinecone provider instantiation");
         PineconeProvider provider = new PineconeProvider();
         org.assertj.core.api.Assertions.assertThat(provider).isNotNull();
+
+        try {
+            EmbeddingStore<TextSegment> pinecone = provider.create();
+        } catch (io.pinecone.exceptions.PineconeAuthorizationException pae) {
+            LOG.info("Successfully caught PineconeAuthorizationException");
+        } catch (Exception e) {
+            fail("Failed to create Pinecone EmbeddingStore {}", e);
+        }
+
         LOG.info("Successfully created Pinecone provider");
     }
 }

--- a/library/ai/vector-dbs/forage-vectordb-pinecone/test-configuration/forage-vectordb-pinecone.properties
+++ b/library/ai/vector-dbs/forage-vectordb-pinecone/test-configuration/forage-vectordb-pinecone.properties
@@ -5,7 +5,7 @@
 # The PineconeConfig class expects simple property names like "api-key", not "pinecone.api-key"
 
 # Authentication
-pinecone.api-key=test_api_key
+pinecone.api.key=test_api_key
 
 # Index configuration
 pinecone.index=test-index-from-file

--- a/library/ai/vector-dbs/forage-vectordb-qdrant/src/test/java/org/apache/camel/forage/vectordb/qdrant/QdrantFileConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-qdrant/src/test/java/org/apache/camel/forage/vectordb/qdrant/QdrantFileConfigTest.java
@@ -2,6 +2,8 @@ package org.apache.camel.forage.vectordb.qdrant;
 
 import static org.assertj.core.api.Fail.fail;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +39,7 @@ public class QdrantFileConfigTest {
     private static void copyPropertiesFile() {
         try {
             Path sourceFile = Paths.get("test-configuration", PROPERTIES_FILE);
-            Path targetDir = Paths.get("src/test/resources");
+            Path targetDir = Paths.get(".");
             Path targetFile = targetDir.resolve(PROPERTIES_FILE);
 
             Files.createDirectories(targetDir);
@@ -58,7 +60,7 @@ public class QdrantFileConfigTest {
 
     private static void removePropertiesFile() {
         try {
-            Path targetFile = Paths.get("src/test/resources/" + PROPERTIES_FILE);
+            Path targetFile = Paths.get(".", PROPERTIES_FILE);
             if (Files.exists(targetFile)) {
                 Files.delete(targetFile);
                 LOG.info("Removed properties file: {}", targetFile);
@@ -90,7 +92,10 @@ public class QdrantFileConfigTest {
     public void shouldCreateQdrantProviderInstance() {
         LOG.info("Testing Qdrant provider instantiation");
         QdrantProvider provider = new QdrantProvider();
+        EmbeddingStore<TextSegment> embeddingStore = provider.create();
+
         org.assertj.core.api.Assertions.assertThat(provider).isNotNull();
+        org.assertj.core.api.Assertions.assertThat(embeddingStore).isNotNull();
         LOG.info("Successfully created Qdrant provider");
     }
 }

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/org/apache/camel/forage/vectordb/weaviate/WeaviateConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/main/java/org/apache/camel/forage/vectordb/weaviate/WeaviateConfig.java
@@ -127,6 +127,21 @@ public class WeaviateConfig implements Config {
                 .orElse("_metadata");
     }
 
+    public String toString() {
+        String result = String.format(
+                "apiKey: %s, scheme %s, host %s, port %s, useGrpcForInserts %s, securedGrpc %s, objectClass %s, avoidDups %s, consistencyLevel %s",
+                apiKey(),
+                scheme(),
+                host(),
+                port().toString(),
+                useGrpcForInserts().toString(),
+                securedGrpc().toString(),
+                objectClass(),
+                avoidDups().toString(),
+                consistencyLevel().toString());
+        return result;
+    }
+
     @Override
     public void register(String name, String value) {
         Optional<ConfigModule> config = WeaviateConfigEntries.find(prefix, name);

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/src/test/java/org/apache/camel/forage/vectordb/weaviate/WeaviateFileConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/src/test/java/org/apache/camel/forage/vectordb/weaviate/WeaviateFileConfigTest.java
@@ -2,6 +2,8 @@ package org.apache.camel.forage.vectordb.weaviate;
 
 import static org.assertj.core.api.Fail.fail;
 
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +32,7 @@ public class WeaviateFileConfigTest {
     public static void setupWeaviateFileConfiguration() {
         LOG.info("Setting up Weaviate file-based configuration test");
         clearWeaviateSystemProperties();
+        removePropertiesFile();
         copyPropertiesFile();
         LOG.info("Weaviate file-based configuration setup complete");
     }
@@ -37,7 +40,7 @@ public class WeaviateFileConfigTest {
     private static void copyPropertiesFile() {
         try {
             Path sourceFile = Paths.get("test-configuration", PROPERTIES_FILE);
-            Path targetDir = Paths.get("src/test/resources");
+            Path targetDir = Paths.get(".");
             Path targetFile = targetDir.resolve(PROPERTIES_FILE);
 
             Files.createDirectories(targetDir);
@@ -58,7 +61,7 @@ public class WeaviateFileConfigTest {
 
     private static void removePropertiesFile() {
         try {
-            Path targetFile = Paths.get("src/test/resources/" + PROPERTIES_FILE);
+            Path targetFile = Paths.get(".", PROPERTIES_FILE);
             if (Files.exists(targetFile)) {
                 Files.delete(targetFile);
                 LOG.info("Removed properties file: {}", targetFile);
@@ -104,7 +107,9 @@ public class WeaviateFileConfigTest {
     public void shouldCreateWeaviateProviderInstance() {
         LOG.info("Testing Weaviate provider instantiation");
         WeaviateProvider provider = new WeaviateProvider();
+        EmbeddingStore<TextSegment> wes = provider.create();
         org.assertj.core.api.Assertions.assertThat(provider).isNotNull();
+        org.assertj.core.api.Assertions.assertThat(wes).isNotNull();
         LOG.info("Successfully created Weaviate provider");
     }
 }

--- a/library/ai/vector-dbs/forage-vectordb-weaviate/test-configuration/forage-vectordb-weaviate.properties
+++ b/library/ai/vector-dbs/forage-vectordb-weaviate/test-configuration/forage-vectordb-weaviate.properties
@@ -1,8 +1,5 @@
 # Weaviate Vector Database Configuration
 # This file demonstrates file-based configuration for Weaviate integration tests
-# 
-# IMPORTANT: Property names should NOT include the "weaviate." prefix
-# The WeaviateConfig class expects simple property names like "host", not "weaviate.host"
 
 # Authentication
 weaviate.api-key=test_api_key
@@ -13,12 +10,12 @@ weaviate.host=localhost
 weaviate.port=8080
 
 # gRPC configuration
-weaviate.use-grpc-for-inserts=false
-weaviate.secured-grpc=false
-weaviate.grpc-port=50051
+weaviate.use.grpc.for.inserts=false
+weaviate.secured.grpc=false
+weaviate.grpc.port=50051
 
 # Object configuration
-weaviate.object-class=TestVectors
+weaviate.object.class=TestVectors
 weaviate.avoid.dups=true
 weaviate.consistency.level=ONE
 


### PR DESCRIPTION
- Adding a provider.create to each one of the FileConfigTests and when necessary wrapping it in a try/catch
- Use "." in properties files instead of "-" for properties