### PR TITLE
Add neo4j support

### DIFF
--- a/library/ai/vector-dbs/forage-vectordb-neo4j/pom.xml
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.forage</groupId>
+        <artifactId>vectordbs</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>forage-vectordb-neo4j</artifactId>
+    <name>Camel Forage :: Library :: AI :: Vector Databases :: Neo4j</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.forage</groupId>
+            <artifactId>forage-core-vectordb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-neo4j</artifactId>
+            <version>${langchain4j-community-version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>neo4j</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/org/apache/camel/forage/vectordb/neo4j/Neo4jConfig.java
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/org/apache/camel/forage/vectordb/neo4j/Neo4jConfig.java
@@ -1,0 +1,345 @@
+package org.apache.camel.forage.vectordb.neo4j;
+
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.AUTO_CREATE_FULL_TEXT;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.AWAIT_INDEX_TIMEOUT;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.CONNECTION_ACQUISITION_TIMEOUT;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.CONNECTION_TIMEOUT;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.DATABASE_NAME;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.DIMENSION;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.EMBEDDING_PROPERTY;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.ENTITY_CREATION_QUERY;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.FULL_TEXT_INDEX_NAME;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.FULL_TEXT_QUERY;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.FULL_TEXT_RETRIEVAL_QUERY;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.ID_PROPERTY;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.INDEX_NAME;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.LABEL;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.MAX_CONNECTION_LIFETIME;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.MAX_CONNECTION_POOL_SIZE;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.METADATA_PREFIX;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.PASSWORD;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.RETRIEVAL_QUERY;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.TEXT_PROPERTY;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.URI;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.USER;
+import static org.apache.camel.forage.vectordb.neo4j.Neo4jConfigEntries.WITH_ENCRYPTION;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.core.util.config.MissingConfigException;
+
+/**
+ * Configuration class for Neo4j vector database integration in the Camel Forage framework.
+ *
+ * <p>This configuration class manages the settings required to connect to and use Neo4j
+ * as a vector database. It handles server connection details, index configuration,
+ * graph properties, and connection pool parameters through environment variables with
+ * appropriate fallback mechanisms and default values.
+ *
+ * <p><strong>Configuration Parameters:</strong>
+ * <ul>
+ *   <li><strong>NEO4J_URI</strong> - The Neo4j server URI (default: "bolt://localhost:7687")</li>
+ *   <li><strong>NEO4J_USER</strong> - The Neo4j username (default: "neo4j")</li>
+ *   <li><strong>NEO4J_PASSWORD</strong> - The Neo4j password (required)</li>
+ *   <li><strong>NEO4J_DATABASE_NAME</strong> - The database name (default: "neo4j")</li>
+ *   <li><strong>NEO4J_INDEX_NAME</strong> - The vector index name (default: "vector-index")</li>
+ *   <li><strong>NEO4J_LABEL</strong> - The node label (default: "Document")</li>
+ *   <li><strong>NEO4J_EMBEDDING_PROPERTY</strong> - The embedding property name (default: "embedding")</li>
+ *   <li><strong>NEO4J_TEXT_PROPERTY</strong> - The text property name (default: "text")</li>
+ *   <li><strong>NEO4J_ID_PROPERTY</strong> - The ID property name (default: "id")</li>
+ *   <li><strong>NEO4J_METADATA_PREFIX</strong> - The metadata prefix (default: "metadata_")</li>
+ *   <li><strong>NEO4J_DIMENSION</strong> - The dimension of the vectors (required)</li>
+ *   <li><strong>NEO4J_WITH_ENCRYPTION</strong> - Enable SSL encryption (default: false)</li>
+ *   <li><strong>NEO4J_CONNECTION_TIMEOUT</strong> - Connection timeout in seconds (default: 30)</li>
+ *   <li><strong>NEO4J_MAX_CONNECTION_LIFETIME</strong> - Max connection lifetime in minutes (default: 60)</li>
+ *   <li><strong>NEO4J_MAX_CONNECTION_POOL_SIZE</strong> - Max connection pool size (default: 100)</li>
+ *   <li><strong>NEO4J_CONNECTION_ACQUISITION_TIMEOUT</strong> - Connection acquisition timeout in seconds (default: 60)</li>
+ *   <li><strong>NEO4J_AWAIT_INDEX_TIMEOUT</strong> - Index creation timeout in seconds (default: 60)</li>
+ *   <li><strong>NEO4J_RETRIEVAL_QUERY</strong> - Custom retrieval query (optional)</li>
+ *   <li><strong>NEO4J_ENTITY_CREATION_QUERY</strong> - Custom entity creation query (optional)</li>
+ *   <li><strong>NEO4J_FULL_TEXT_INDEX_NAME</strong> - Full text index name (optional)</li>
+ *   <li><strong>NEO4J_FULL_TEXT_QUERY</strong> - Full text query (optional)</li>
+ *   <li><strong>NEO4J_FULL_TEXT_RETRIEVAL_QUERY</strong> - Full text retrieval query (optional)</li>
+ *   <li><strong>NEO4J_AUTO_CREATE_FULL_TEXT</strong> - Auto create full text index (default: false)</li>
+ * </ul>
+ *
+ * <p><strong>Configuration Sources:</strong>
+ * Configuration values are resolved in the following order of precedence:
+ * <ol>
+ *   <li>Environment variables (NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD, etc.)</li>
+ *   <li>System properties (neo4j.uri, neo4j.user, neo4j.password, etc.)</li>
+ *   <li>forage-vectordb-neo4j.properties file in classpath</li>
+ *   <li>Default values if none of the above are provided</li>
+ * </ol>
+ *
+ * <p><strong>Usage Example:</strong>
+ * <pre>{@code
+ * // Set environment variables (optional)
+ * export NEO4J_URI="bolt://neo4j.example.com:7687"
+ * export NEO4J_USER="neo4j"
+ * export NEO4J_PASSWORD="password"
+ * export NEO4J_DIMENSION="384"
+ * export NEO4J_INDEX_NAME="my_vector_index"
+ * export NEO4J_LABEL="Document"
+ *
+ * // Create and use configuration
+ * Neo4jConfig config = new Neo4jConfig();
+ * String uri = config.uri();                  // Returns the configured URI
+ * String user = config.user();                // Returns the configured user
+ * int dimension = config.dimension();         // Returns the configured dimension
+ * }</pre>
+ *
+ * <p>This class automatically registers itself and its configuration parameters with the
+ * {@link ConfigStore} during construction, making the configuration values available
+ * to other components in the framework.
+ *
+ * @see Config
+ * @see ConfigStore
+ * @see ConfigModule
+ * @since 1.0
+ */
+public class Neo4jConfig implements Config {
+
+    private static final String DEFAULT_URI = "bolt://localhost:7687";
+    private static final String DEFAULT_USER = "neo4j";
+    private static final String DEFAULT_DATABASE_NAME = "neo4j";
+    private static final String DEFAULT_INDEX_NAME = "vector-index";
+    private static final String DEFAULT_LABEL = "Document";
+    private static final String DEFAULT_EMBEDDING_PROPERTY = "embedding";
+    private static final String DEFAULT_TEXT_PROPERTY = "text";
+    private static final String DEFAULT_ID_PROPERTY = "id";
+    private static final String DEFAULT_METADATA_PREFIX = "metadata_";
+    private static final boolean DEFAULT_WITH_ENCRYPTION = false;
+    private static final int DEFAULT_CONNECTION_TIMEOUT = 30;
+    private static final int DEFAULT_MAX_CONNECTION_LIFETIME = 60;
+    private static final int DEFAULT_MAX_CONNECTION_POOL_SIZE = 100;
+    private static final int DEFAULT_CONNECTION_ACQUISITION_TIMEOUT = 60;
+    private static final int DEFAULT_AWAIT_INDEX_TIMEOUT = 60;
+    private static final boolean DEFAULT_AUTO_CREATE_FULL_TEXT = false;
+    private final String prefix;
+
+    public Neo4jConfig() {
+        this(null);
+    }
+
+    public Neo4jConfig(String prefix) {
+        this.prefix = prefix;
+
+        // First register new configuration modules. This happens only if a prefix is provided
+        Neo4jConfigEntries.register(prefix);
+
+        // Then, loads the configurations from the properties file associated with this Config module
+        ConfigStore.getInstance().load(Neo4jConfig.class, this, this::register);
+
+        // Lastly, load the overrides defined in system properties and environment variables
+        Neo4jConfigEntries.loadOverrides(prefix);
+    }
+
+    @Override
+    public void register(String name, String value) {
+        Optional<ConfigModule> config = Neo4jConfigEntries.find(prefix, name);
+
+        config.ifPresent(module -> ConfigStore.getInstance().set(module, value));
+    }
+
+    @Override
+    public String name() {
+        return "forage-vectordb-neo4j";
+    }
+
+    /**
+     * Returns the Neo4j server URI.
+     */
+    public String uri() {
+        return ConfigStore.getInstance().get(URI.asNamed(prefix)).orElse(DEFAULT_URI);
+    }
+
+    /**
+     * Returns the Neo4j username.
+     */
+    public String user() {
+        return ConfigStore.getInstance().get(USER.asNamed(prefix)).orElse(DEFAULT_USER);
+    }
+
+    /**
+     * Returns the Neo4j password.
+     */
+    public String password() {
+        return ConfigStore.getInstance()
+                .get(PASSWORD.asNamed(prefix))
+                .orElseThrow(() -> new MissingConfigException("Neo4j password is required but not configured"));
+    }
+
+    /**
+     * Returns the database name.
+     */
+    public String databaseName() {
+        return ConfigStore.getInstance().get(DATABASE_NAME.asNamed(prefix)).orElse(DEFAULT_DATABASE_NAME);
+    }
+
+    /**
+     * Returns the vector index name.
+     */
+    public String indexName() {
+        return ConfigStore.getInstance().get(INDEX_NAME.asNamed(prefix)).orElse(DEFAULT_INDEX_NAME);
+    }
+
+    /**
+     * Returns the node label.
+     */
+    public String label() {
+        return ConfigStore.getInstance().get(LABEL.asNamed(prefix)).orElse(DEFAULT_LABEL);
+    }
+
+    /**
+     * Returns the embedding property name.
+     */
+    public String embeddingProperty() {
+        return ConfigStore.getInstance().get(EMBEDDING_PROPERTY.asNamed(prefix)).orElse(DEFAULT_EMBEDDING_PROPERTY);
+    }
+
+    /**
+     * Returns the text property name.
+     */
+    public String textProperty() {
+        return ConfigStore.getInstance().get(TEXT_PROPERTY.asNamed(prefix)).orElse(DEFAULT_TEXT_PROPERTY);
+    }
+
+    /**
+     * Returns the ID property name.
+     */
+    public String idProperty() {
+        return ConfigStore.getInstance().get(ID_PROPERTY.asNamed(prefix)).orElse(DEFAULT_ID_PROPERTY);
+    }
+
+    /**
+     * Returns the metadata prefix.
+     */
+    public String metadataPrefix() {
+        return ConfigStore.getInstance().get(METADATA_PREFIX.asNamed(prefix)).orElse(DEFAULT_METADATA_PREFIX);
+    }
+
+    /**
+     * Returns the dimension of the vectors.
+     */
+    public int dimension() {
+        return ConfigStore.getInstance()
+                .get(DIMENSION.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElseThrow(() -> new MissingConfigException("Vector dimension is required but not configured"));
+    }
+
+    /**
+     * Returns whether SSL encryption is enabled.
+     */
+    public boolean withEncryption() {
+        return ConfigStore.getInstance()
+                .get(WITH_ENCRYPTION.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(DEFAULT_WITH_ENCRYPTION);
+    }
+
+    /**
+     * Returns the connection timeout duration.
+     */
+    public Duration connectionTimeout() {
+        return Duration.ofSeconds(ConfigStore.getInstance()
+                .get(CONNECTION_TIMEOUT.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(DEFAULT_CONNECTION_TIMEOUT));
+    }
+
+    /**
+     * Returns the maximum connection lifetime duration.
+     */
+    public Duration maxConnectionLifetime() {
+        return Duration.ofMinutes(ConfigStore.getInstance()
+                .get(MAX_CONNECTION_LIFETIME.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(DEFAULT_MAX_CONNECTION_LIFETIME));
+    }
+
+    /**
+     * Returns the maximum connection pool size.
+     */
+    public int maxConnectionPoolSize() {
+        return ConfigStore.getInstance()
+                .get(MAX_CONNECTION_POOL_SIZE.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(DEFAULT_MAX_CONNECTION_POOL_SIZE);
+    }
+
+    /**
+     * Returns the connection acquisition timeout duration.
+     */
+    public Duration connectionAcquisitionTimeout() {
+        return Duration.ofSeconds(ConfigStore.getInstance()
+                .get(CONNECTION_ACQUISITION_TIMEOUT.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(DEFAULT_CONNECTION_ACQUISITION_TIMEOUT));
+    }
+
+    /**
+     * Returns the index creation timeout duration.
+     */
+    public Duration awaitIndexTimeout() {
+        return Duration.ofSeconds(ConfigStore.getInstance()
+                .get(AWAIT_INDEX_TIMEOUT.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(DEFAULT_AWAIT_INDEX_TIMEOUT));
+    }
+
+    /**
+     * Returns the custom retrieval query.
+     */
+    public String retrievalQuery() {
+        return ConfigStore.getInstance().get(RETRIEVAL_QUERY.asNamed(prefix)).orElse(null);
+    }
+
+    /**
+     * Returns the custom entity creation query.
+     */
+    public String entityCreationQuery() {
+        return ConfigStore.getInstance()
+                .get(ENTITY_CREATION_QUERY.asNamed(prefix))
+                .orElse(null);
+    }
+
+    /**
+     * Returns the full text index name.
+     */
+    public String fullTextIndexName() {
+        return ConfigStore.getInstance()
+                .get(FULL_TEXT_INDEX_NAME.asNamed(prefix))
+                .orElse(null);
+    }
+
+    /**
+     * Returns the full text query.
+     */
+    public String fullTextQuery() {
+        return ConfigStore.getInstance().get(FULL_TEXT_QUERY.asNamed(prefix)).orElse(null);
+    }
+
+    /**
+     * Returns the full text retrieval query.
+     */
+    public String fullTextRetrievalQuery() {
+        return ConfigStore.getInstance()
+                .get(FULL_TEXT_RETRIEVAL_QUERY.asNamed(prefix))
+                .orElse(null);
+    }
+
+    /**
+     * Returns whether to auto create full text index.
+     */
+    public boolean autoCreateFullText() {
+        return ConfigStore.getInstance()
+                .get(AUTO_CREATE_FULL_TEXT.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(DEFAULT_AUTO_CREATE_FULL_TEXT);
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/org/apache/camel/forage/vectordb/neo4j/Neo4jConfigEntries.java
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/org/apache/camel/forage/vectordb/neo4j/Neo4jConfigEntries.java
@@ -1,0 +1,106 @@
+package org.apache.camel.forage.vectordb.neo4j;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.camel.forage.core.util.config.ConfigEntries;
+import org.apache.camel.forage.core.util.config.ConfigEntry;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+
+public final class Neo4jConfigEntries extends ConfigEntries {
+    public static final ConfigModule INDEX_NAME = ConfigModule.of(Neo4jConfig.class, "neo4j.index.name");
+    public static final ConfigModule METADATA_PREFIX = ConfigModule.of(Neo4jConfig.class, "neo4j.metadata.prefix");
+    public static final ConfigModule EMBEDDING_PROPERTY =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.embedding.property");
+    public static final ConfigModule ID_PROPERTY = ConfigModule.of(Neo4jConfig.class, "neo4j.id.property");
+    public static final ConfigModule LABEL = ConfigModule.of(Neo4jConfig.class, "neo4j.label");
+    public static final ConfigModule TEXT_PROPERTY = ConfigModule.of(Neo4jConfig.class, "neo4j.text.property");
+    public static final ConfigModule DATABASE_NAME = ConfigModule.of(Neo4jConfig.class, "neo4j.database.name");
+    public static final ConfigModule RETRIEVAL_QUERY = ConfigModule.of(Neo4jConfig.class, "neo4j.retrieval.query");
+    public static final ConfigModule DIMENSION = ConfigModule.of(Neo4jConfig.class, "neo4j.dimension");
+    public static final ConfigModule AWAIT_INDEX_TIMEOUT =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.await.index.timeout");
+    public static final ConfigModule FULL_TEXT_INDEX_NAME =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.full.text.index.name");
+    public static final ConfigModule FULL_TEXT_QUERY = ConfigModule.of(Neo4jConfig.class, "neo4j.full.text.query");
+    public static final ConfigModule FULL_TEXT_RETRIEVAL_QUERY =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.full.text.retrieval.query");
+    public static final ConfigModule AUTO_CREATE_FULL_TEXT =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.auto.create.full.text");
+    public static final ConfigModule ENTITY_CREATION_QUERY =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.entity.creation.query");
+    public static final ConfigModule URI = ConfigModule.of(Neo4jConfig.class, "neo4j.uri");
+    public static final ConfigModule USER = ConfigModule.of(Neo4jConfig.class, "neo4j.user");
+    public static final ConfigModule PASSWORD = ConfigModule.of(Neo4jConfig.class, "neo4j.password");
+    public static final ConfigModule WITH_ENCRYPTION = ConfigModule.of(Neo4jConfig.class, "neo4j.with.encryption");
+    public static final ConfigModule CONNECTION_TIMEOUT =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.connection.timeout");
+    public static final ConfigModule MAX_CONNECTION_LIFETIME =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.max.connection.lifetime");
+    public static final ConfigModule MAX_CONNECTION_POOL_SIZE =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.max.connection.pool.size");
+    public static final ConfigModule CONNECTION_ACQUISITION_TIMEOUT =
+            ConfigModule.of(Neo4jConfig.class, "neo4j.connection.acquisition.timeout");
+
+    private static final Map<ConfigModule, ConfigEntry> CONFIG_MODULES = new ConcurrentHashMap<>();
+
+    static {
+        init();
+    }
+
+    static void init() {
+        CONFIG_MODULES.put(INDEX_NAME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(METADATA_PREFIX, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(EMBEDDING_PROPERTY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(ID_PROPERTY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(LABEL, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TEXT_PROPERTY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(DATABASE_NAME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(RETRIEVAL_QUERY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(DIMENSION, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AWAIT_INDEX_TIMEOUT, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(FULL_TEXT_INDEX_NAME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(FULL_TEXT_QUERY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(FULL_TEXT_RETRIEVAL_QUERY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AUTO_CREATE_FULL_TEXT, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(ENTITY_CREATION_QUERY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(URI, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(USER, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(PASSWORD, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(WITH_ENCRYPTION, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(CONNECTION_TIMEOUT, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MAX_CONNECTION_LIFETIME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(MAX_CONNECTION_POOL_SIZE, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(CONNECTION_ACQUISITION_TIMEOUT, ConfigEntry.fromModule());
+    }
+
+    public static Map<ConfigModule, ConfigEntry> entries() {
+        return Collections.unmodifiableMap(CONFIG_MODULES);
+    }
+
+    public static Optional<ConfigModule> find(String prefix, String name) {
+        return find(CONFIG_MODULES, prefix, name);
+    }
+
+    /**
+     * Registers new known configuration if a prefix is provided (otherwise is ignored)
+     * @param prefix the prefix to register
+     */
+    public static void register(String prefix) {
+        if (prefix != null) {
+            for (Map.Entry<ConfigModule, ConfigEntry> entry : entries().entrySet()) {
+                ConfigModule configModule = entry.getKey().asNamed(prefix);
+                CONFIG_MODULES.put(configModule, ConfigEntry.fromModule());
+            }
+        }
+    }
+
+    /**
+     * Load override configurations (which are defined via environment variables and/or system properties)
+     * @param prefix and optional prefix to use
+     */
+    public static void loadOverrides(String prefix) {
+        load(CONFIG_MODULES, prefix);
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/org/apache/camel/forage/vectordb/neo4j/Neo4jProvider.java
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/java/org/apache/camel/forage/vectordb/neo4j/Neo4jProvider.java
@@ -1,0 +1,140 @@
+package org.apache.camel.forage.vectordb.neo4j;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provider for creating Neo4j embedding stores with configurable parameters.
+ *
+ * <p>This provider creates instances of {@link Neo4jEmbeddingStore} using configuration
+ * values managed by {@link Neo4jConfig}. The configuration supports environment
+ * variables, system properties, and configuration files for flexible deployment.
+ *
+ * <p><strong>Configuration:</strong>
+ * <ul>
+ *   <li>URI: Configured via NEO4J_URI environment variable or defaults to "bolt://localhost:7687"</li>
+ *   <li>User: Configured via NEO4J_USER environment variable or defaults to "neo4j"</li>
+ *   <li>Password: Required configuration via NEO4J_PASSWORD environment variable</li>
+ *   <li>Database Name: Configured via NEO4J_DATABASE_NAME environment variable or defaults to "neo4j"</li>
+ *   <li>Index Name: Configured via NEO4J_INDEX_NAME environment variable or defaults to "vector-index"</li>
+ *   <li>Label: Configured via NEO4J_LABEL environment variable or defaults to "Document"</li>
+ *   <li>Embedding Property: Configured via NEO4J_EMBEDDING_PROPERTY environment variable or defaults to "embedding"</li>
+ *   <li>Text Property: Configured via NEO4J_TEXT_PROPERTY environment variable or defaults to "text"</li>
+ *   <li>ID Property: Configured via NEO4J_ID_PROPERTY environment variable or defaults to "id"</li>
+ *   <li>Metadata Prefix: Configured via NEO4J_METADATA_PREFIX environment variable or defaults to "metadata_"</li>
+ *   <li>Dimension: Required configuration via NEO4J_DIMENSION environment variable</li>
+ *   <li>With Encryption: Configured via NEO4J_WITH_ENCRYPTION environment variable or defaults to false</li>
+ *   <li>Connection Timeout: Configured via NEO4J_CONNECTION_TIMEOUT environment variable or defaults to 30 seconds</li>
+ *   <li>Max Connection Lifetime: Configured via NEO4J_MAX_CONNECTION_LIFETIME environment variable or defaults to 60 minutes</li>
+ *   <li>Max Connection Pool Size: Configured via NEO4J_MAX_CONNECTION_POOL_SIZE environment variable or defaults to 100</li>
+ *   <li>Connection Acquisition Timeout: Configured via NEO4J_CONNECTION_ACQUISITION_TIMEOUT environment variable or defaults to 60 seconds</li>
+ *   <li>Await Index Timeout: Configured via NEO4J_AWAIT_INDEX_TIMEOUT environment variable or defaults to 60 seconds</li>
+ * </ul>
+ *
+ * <p><strong>Usage:</strong>
+ * <pre>{@code
+ * // Configuration is automatic through environment variables or defaults
+ * Neo4jProvider provider = new Neo4jProvider();
+ * EmbeddingStore<TextSegment> store = provider.create();
+ * }</pre>
+ *
+ * @see Neo4jConfig
+ * @see EmbeddingStoreProvider
+ * @since 1.0
+ */
+public class Neo4jProvider implements EmbeddingStoreProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(Neo4jProvider.class);
+
+    /**
+     * Creates a new Neo4j embedding store instance with the configured parameters.
+     *
+     * <p>This method creates a {@link Neo4jEmbeddingStore} using the connection details
+     * and configuration from the Neo4jConfig. The store is ready to use for vector
+     * operations once created.
+     *
+     * @param id optional configuration prefix for named instances
+     * @return a new configured Neo4j embedding store instance
+     */
+    @Override
+    public EmbeddingStore<TextSegment> create(String id) {
+        final Neo4jConfig config = new Neo4jConfig(id);
+
+        String uri = config.uri();
+        String user = config.user();
+        String password = config.password();
+        String databaseName = config.databaseName();
+        String indexName = config.indexName();
+        String label = config.label();
+        String embeddingProperty = config.embeddingProperty();
+        String textProperty = config.textProperty();
+        String idProperty = config.idProperty();
+        String metadataPrefix = config.metadataPrefix();
+        int dimension = config.dimension();
+        boolean withEncryption = config.withEncryption();
+
+        LOG.trace(
+                "Creating Neo4j embedding store: {} with configuration: user={}, database={}, index={}, label={}, embeddingProperty={}, textProperty={}, idProperty={}, metadataPrefix={}, dimension={}, withEncryption={}",
+                uri,
+                user,
+                databaseName,
+                indexName,
+                label,
+                embeddingProperty,
+                textProperty,
+                idProperty,
+                metadataPrefix,
+                dimension,
+                withEncryption);
+
+        Neo4jEmbeddingStore.Builder builder = Neo4jEmbeddingStore.builder()
+                .databaseName(databaseName)
+                .indexName(indexName)
+                .label(label)
+                .embeddingProperty(embeddingProperty)
+                .textProperty(textProperty)
+                .idProperty(idProperty)
+                .metadataPrefix(metadataPrefix)
+                .dimension(dimension);
+
+        // use basic auth
+        if ((uri != null && !uri.trim().isEmpty())
+                && (user != null && !user.trim().isEmpty())
+                && (password != null && !password.trim().isEmpty())) {
+            builder.withBasicAuth(uri, user, password);
+        }
+
+        // Set optional custom queries if configured
+        String retrievalQuery = config.retrievalQuery();
+        if (retrievalQuery != null && !retrievalQuery.trim().isEmpty()) {
+            builder.retrievalQuery(retrievalQuery);
+        }
+
+        String entityCreationQuery = config.entityCreationQuery();
+        if (entityCreationQuery != null && !entityCreationQuery.trim().isEmpty()) {
+            builder.entityCreationQuery(entityCreationQuery);
+        }
+
+        String fullTextIndexName = config.fullTextIndexName();
+        if (fullTextIndexName != null && !fullTextIndexName.trim().isEmpty()) {
+            builder.fullTextIndexName(fullTextIndexName);
+        }
+
+        String fullTextQuery = config.fullTextQuery();
+        if (fullTextQuery != null && !fullTextQuery.trim().isEmpty()) {
+            builder.fullTextQuery(fullTextQuery);
+        }
+
+        String fullTextRetrievalQuery = config.fullTextRetrievalQuery();
+        if (fullTextRetrievalQuery != null && !fullTextRetrievalQuery.trim().isEmpty()) {
+            builder.fullTextRetrievalQuery(fullTextRetrievalQuery);
+        }
+
+        builder.autoCreateFullText(config.autoCreateFullText());
+
+        return builder.build();
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/src/main/resources/META-INF/services/org.apache.camel.forage.core.vectordb.EmbeddingStoreProvider
@@ -1,0 +1,1 @@
+org.apache.camel.forage.vectordb.neo4j.Neo4jProvider

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/src/test/java/org/apache/camel/forage/vectordb/neo4j/Neo4jFileConfigTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/src/test/java/org/apache/camel/forage/vectordb/neo4j/Neo4jFileConfigTest.java
@@ -1,0 +1,139 @@
+package org.apache.camel.forage.vectordb.neo4j;
+
+import static org.assertj.core.api.Fail.fail;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit test for Neo4j vector database using file-based configuration.
+ *
+ * <p>This test demonstrates how the Camel Forage framework can load configuration
+ * from properties files instead of system properties or environment variables.
+ * The configuration is loaded from the 'forage-vectordb-neo4j.properties' file
+ * on the classpath.
+ */
+public class Neo4jFileConfigTest {
+    private static final Logger LOG = LoggerFactory.getLogger(Neo4jFileConfigTest.class);
+
+    private static final String PROPERTIES_FILE = "forage-vectordb-neo4j.properties";
+
+    @BeforeAll
+    public static void setupNeo4jFileConfiguration() {
+        LOG.info("Setting up Neo4j file-based configuration test");
+        clearNeo4jSystemProperties();
+        copyPropertiesFile();
+        LOG.info("Neo4j file-based configuration setup complete");
+    }
+
+    private static void copyPropertiesFile() {
+        try {
+            Path sourceFile = Paths.get("test-configuration", PROPERTIES_FILE);
+            Path targetDir = Paths.get(".");
+            Path targetFile = targetDir.resolve(PROPERTIES_FILE);
+
+            Files.createDirectories(targetDir);
+            Files.copy(sourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
+            LOG.info("Copied {} to {}", sourceFile, targetFile);
+        } catch (IOException e) {
+            fail("Failed to copy properties file: {}", e.getMessage());
+        }
+    }
+
+    @AfterAll
+    public static void teardownNeo4jFileConfiguration() {
+        LOG.info("Cleaning up Neo4j file-based configuration");
+        clearNeo4jSystemProperties();
+        removePropertiesFile();
+        LOG.info("Neo4j file-based configuration cleanup complete");
+    }
+
+    private static void removePropertiesFile() {
+        try {
+            Path targetFile = Paths.get(".", PROPERTIES_FILE);
+            if (Files.exists(targetFile)) {
+                Files.delete(targetFile);
+                LOG.info("Removed properties file: {}", targetFile);
+            }
+        } catch (IOException e) {
+            fail("Failed to remove properties file: {}", e.getMessage());
+        }
+    }
+
+    private static void clearNeo4jSystemProperties() {
+        // Clear all possible neo4j system properties based on Neo4jConfig
+        System.clearProperty("neo4j.uri");
+        System.clearProperty("neo4j.user");
+        System.clearProperty("neo4j.password");
+        System.clearProperty("neo4j.database.name");
+        System.clearProperty("neo4j.index.name");
+        System.clearProperty("neo4j.label");
+        System.clearProperty("neo4j.embedding.property");
+        System.clearProperty("neo4j.text.property");
+        System.clearProperty("neo4j.id.property");
+        System.clearProperty("neo4j.metadata.prefix");
+        System.clearProperty("neo4j.dimension");
+        System.clearProperty("neo4j.with.encryption");
+        System.clearProperty("neo4j.connection.timeout");
+        System.clearProperty("neo4j.max.connection.lifetime");
+        System.clearProperty("neo4j.max.connection.pool.size");
+        System.clearProperty("neo4j.connection.acquisition.timeout");
+        System.clearProperty("neo4j.await.index.timeout");
+        System.clearProperty("neo4j.retrieval.query");
+        System.clearProperty("neo4j.entity.creation.query");
+        System.clearProperty("neo4j.full.text.index.name");
+        System.clearProperty("neo4j.full.text.query");
+        System.clearProperty("neo4j.full.text.retrieval.query");
+        System.clearProperty("neo4j.auto.create.full.text");
+
+        // Also clear the simple property names (without neo4j prefix)
+        System.clearProperty("uri");
+        System.clearProperty("user");
+        System.clearProperty("password");
+        System.clearProperty("database.name");
+        System.clearProperty("index.name");
+        System.clearProperty("label");
+        System.clearProperty("embedding.property");
+        System.clearProperty("text.property");
+        System.clearProperty("id.property");
+        System.clearProperty("metadata.prefix");
+        System.clearProperty("dimension");
+        System.clearProperty("with.encryption");
+        System.clearProperty("connection.timeout");
+        System.clearProperty("max.connection.lifetime");
+        System.clearProperty("max.connection.pool.size");
+        System.clearProperty("connection.acquisition.timeout");
+        System.clearProperty("await.index.timeout");
+        System.clearProperty("retrieval.query");
+        System.clearProperty("entity.creation.query");
+        System.clearProperty("full.text.index.name");
+        System.clearProperty("full.text.query");
+        System.clearProperty("full.text.retrieval.query");
+        System.clearProperty("auto.create.full.text");
+    }
+
+    @Test
+    public void shouldCreateNeo4jProviderInstance() {
+        LOG.info("Testing Neo4j provider instantiation");
+        Neo4jProvider provider = new Neo4jProvider();
+        org.assertj.core.api.Assertions.assertThat(provider).isNotNull();
+        try {
+            EmbeddingStore<TextSegment> neo4jboo = provider.create();
+        } catch (org.neo4j.driver.exceptions.ServiceUnavailableException sue) {
+            LOG.info("Expected to catch RuntimeException creating Neo4j Embedding Store and did successfully...");
+        } catch (Exception e) {
+            fail("Caught exception trying to create Neo4j Embedding Store {}", e);
+        }
+        LOG.info("Successfully created Neo4j provider");
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/src/test/java/org/apache/camel/forage/vectordb/neo4j/Neo4jIntegrationTest.java
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/src/test/java/org/apache/camel/forage/vectordb/neo4j/Neo4jIntegrationTest.java
@@ -1,0 +1,156 @@
+package org.apache.camel.forage.vectordb.neo4j;
+
+import static org.assertj.core.api.Fail.fail;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration test for Neo4j vector database using Testcontainers.
+ *
+ * <p>This test demonstrates how the Camel Forage framework can integrate with Neo4j
+ * using dynamic configuration and real database operations. The test uses Testcontainers
+ * to spin up a real Neo4j instance and performs basic vector operations.
+ */
+@Testcontainers
+public class Neo4jIntegrationTest {
+    private static final Logger LOG = LoggerFactory.getLogger(Neo4jIntegrationTest.class);
+
+    private static final int dimension = 4;
+    private static final String indexName = "test_vector_index";
+    private static final String label = "TestDocument";
+
+    @Container
+    private static final Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:5.15")
+            .withAdminPassword("test_password")
+            .withStartupAttempts(3);
+
+    @BeforeAll
+    public static void setupNeo4jConfiguration() {
+        // Remove any existing properties file to ensure clean state
+        try {
+            Path propertiesFile = Paths.get("src/test/resources/forage-vectordb-neo4j.properties");
+            if (Files.exists(propertiesFile)) {
+                Files.delete(propertiesFile);
+                LOG.info("Removed src/test/resources/forage-vectordb-neo4j.properties");
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to remove properties file: {}", e.getMessage());
+        }
+
+        LOG.info("Setting up Neo4j configuration with container: {}", neo4jContainer.getDockerImageName());
+
+        String boltUrl = neo4jContainer.getBoltUrl();
+        String password = neo4jContainer.getAdminPassword();
+
+        // Set system properties with the dynamic container values
+        System.setProperty("neo4j.uri", boltUrl);
+        System.setProperty("neo4j.user", "neo4j");
+        System.setProperty("neo4j.password", password);
+        System.setProperty("neo4j.database.name", "neo4j");
+        System.setProperty("neo4j.index.name", indexName);
+        System.setProperty("neo4j.label", label);
+        System.setProperty("neo4j.embedding.property", "embedding");
+        System.setProperty("neo4j.text.property", "text");
+        System.setProperty("neo4j.id.property", "id");
+        System.setProperty("neo4j.metadata.prefix", "meta_");
+        System.setProperty("neo4j.dimension", Integer.toString(dimension));
+        System.setProperty("neo4j.with.encryption", "false");
+        System.setProperty("neo4j.await.index.timeout", "120");
+
+        LOG.info("Neo4j container configured - Bolt URL: {}", boltUrl);
+        LOG.info("Neo4j index configured: {}", indexName);
+    }
+
+    @AfterAll
+    public static void cleanupNeo4jConfiguration() {
+        LOG.info("Cleaning up Neo4j system properties");
+
+        // Clear system properties
+        System.clearProperty("neo4j.uri");
+        System.clearProperty("neo4j.user");
+        System.clearProperty("neo4j.password");
+        System.clearProperty("neo4j.database.name");
+        System.clearProperty("neo4j.index.name");
+        System.clearProperty("neo4j.label");
+        System.clearProperty("neo4j.embedding.property");
+        System.clearProperty("neo4j.text.property");
+        System.clearProperty("neo4j.id.property");
+        System.clearProperty("neo4j.metadata.prefix");
+        System.clearProperty("neo4j.dimension");
+        System.clearProperty("neo4j.with.encryption");
+        System.clearProperty("neo4j.await.index.timeout");
+
+        LOG.info("Neo4j system properties cleared");
+    }
+
+    @Test
+    public void shouldPerformBasicNeo4jOperations() {
+        LOG.info("Testing basic Neo4j operations");
+
+        Neo4jProvider provider = new Neo4jProvider();
+        EmbeddingStore<TextSegment> embeddingStore = provider.create();
+
+        try {
+            LOG.info("Testing basic embedding operations");
+
+            // Create test embeddings
+            float[] vector1 = {0.1f, 0.2f, 0.3f, 0.4f};
+            float[] vector2 = {0.5f, 0.6f, 0.7f, 0.8f};
+
+            Embedding embedding1 = new Embedding(vector1);
+            Embedding embedding2 = new Embedding(vector2);
+
+            TextSegment segment1 = TextSegment.from("Test document 1", Metadata.from("key1", "value1"));
+            TextSegment segment2 = TextSegment.from("Test document 2", Metadata.from("key2", "value2"));
+
+            // Store embeddings
+            embeddingStore.add(embedding1, segment1);
+            embeddingStore.add(embedding2, segment2);
+
+            // Search for similar embeddings
+            float[] searchVector = {0.1f, 0.2f, 0.3f, 0.4f};
+            Embedding searchEmbedding = new Embedding(searchVector);
+
+            EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                    .queryEmbedding(searchEmbedding)
+                    .maxResults(2)
+                    .minScore(0.0)
+                    .build();
+
+            EmbeddingSearchResult<TextSegment> searchResult = embeddingStore.search(searchRequest);
+            List<EmbeddingMatch<TextSegment>> matches = searchResult.matches();
+
+            LOG.info("Found {} matches", matches.size());
+            for (EmbeddingMatch<TextSegment> match : matches) {
+                LOG.info("Match: {} with score: {}", match.embedded().text(), match.score());
+            }
+
+            // Verify results
+            org.assertj.core.api.Assertions.assertThat(matches).hasSize(2);
+            org.assertj.core.api.Assertions.assertThat(matches.get(0).embedded().text())
+                    .isEqualTo("Test document 1");
+            org.assertj.core.api.Assertions.assertThat(matches.get(0).score()).isGreaterThan(0.8);
+
+        } catch (Exception e) {
+            fail("Neo4j basic operations test failed (expected for some configurations): {}", e.getMessage());
+        }
+    }
+}

--- a/library/ai/vector-dbs/forage-vectordb-neo4j/test-configuration/forage-vectordb-neo4j.properties
+++ b/library/ai/vector-dbs/forage-vectordb-neo4j/test-configuration/forage-vectordb-neo4j.properties
@@ -1,0 +1,35 @@
+# Neo4j Vector Database Configuration
+# This file demonstrates file-based configuration for Neo4j integration tests
+
+# Connection settings
+neo4j.uri=bolt://localhost:7687
+neo4j.user=neo4j
+neo4j.password=test_password
+neo4j.database.name=neo4j
+neo4j.with.encryption=false
+
+# Vector configuration
+neo4j.dimension=384
+neo4j.index.name=test_vector_index
+neo4j.label=TestDocument
+neo4j.embedding.property=embedding
+neo4j.text.property=text
+neo4j.id.property=id
+neo4j.metadata.prefix=meta_
+
+# Connection pool settings
+neo4j.connection.timeout=30
+neo4j.max.connection.lifetime=60
+neo4j.max.connection.pool.size=50
+neo4j.connection.acquisition.timeout=30
+neo4j.await.index.timeout=60
+
+# Full text search settings
+neo4j.full.text.index.name=test_fulltext_index
+neo4j.auto.create.full.text=true
+
+# Custom queries (optional)
+# neo4j.retrieval.query=MATCH (n:Document) WHERE n.id = $id RETURN n
+# neo4j.entity.creation.query=CREATE (n:Document {id: $id, text: $text, embedding: $embedding})
+# neo4j.full.text.query=CALL db.index.fulltext.queryNodes('fulltext_index', $query)
+# neo4j.full.text.retrieval.query=MATCH (n) WHERE id(n) IN $ids RETURN n

--- a/library/ai/vector-dbs/pom.xml
+++ b/library/ai/vector-dbs/pom.xml
@@ -55,6 +55,7 @@
         <module>forage-vectordb-chroma</module>
         <module>forage-vectordb-infinispan</module>
         <module>forage-vectordb-milvus</module>
+        <module>forage-vectordb-neo4j</module>
         <module>forage-vectordb-pgvector</module>
         <module>forage-vectordb-pinecone</module>
         <module>forage-vectordb-qdrant</module>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <langchain4j-version>1.4.0</langchain4j-version>
         <langchain4j-beta-version>1.4.0-beta10</langchain4j-beta-version>
-        <langchain4j-community-version>1.4.0-beta10</langchain4j-community-version> 
+        <langchain4j-community-version>1.4.0-beta10</langchain4j-community-version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.25.1</log4j.version>
         <spotless.version>2.46.1</spotless.version>


### PR DESCRIPTION
Add neo4j support

The addition of neo4j and redis pushes forage to parity with Quarkus' support for Document/Vector Stores : https://docs.quarkiverse.io/quarkus-langchain4j/dev/rag.html (Retrieval Augmented Generation -> Document and Vector Stores)