### PR TITLE
Support different versions of LangChain4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,6 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <langchain4j-version>1.3.0</langchain4j-version>
-        <langchain4j-beta-version>1.3.0-beta9</langchain4j-beta-version>
-        <langchain4j-community-version>1.3.0-beta9</langchain4j-community-version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.25.1</log4j.version>
         <spotless.version>2.46.1</spotless.version>
@@ -151,6 +148,9 @@
             <properties>
                 <camel.version>4.14.0</camel.version>
                 <camel-lts>true</camel-lts>
+                <langchain4j-version>1.3.0</langchain4j-version>
+                <langchain4j-beta-version>1.3.0-beta9</langchain4j-beta-version>
+                <langchain4j-community-version>1.3.0-beta9</langchain4j-community-version>
             </properties>
         </profile>
         <profile>
@@ -163,6 +163,10 @@
             </activation>
             <properties>
                 <camel.version>4.15.0-SNAPSHOT</camel.version>
+                <langchain4j-version>1.4.0</langchain4j-version>
+                <langchain4j-beta-version>1.4.0-beta10</langchain4j-beta-version>
+                <langchain4j-community-version>1.4.0-beta10</langchain4j-community-version>
+
             </properties>
 
             <repositories>


### PR DESCRIPTION
Use either 1.3.0 or 1.4.0 depending on the Maven profile used.