### PR TITLE
Forage export (run)

### DIFF
--- a/core/forage-core-common/src/main/java/org/apache/camel/forage/core/common/ExportCustomizer.java
+++ b/core/forage-core-common/src/main/java/org/apache/camel/forage/core/common/ExportCustomizer.java
@@ -1,0 +1,20 @@
+package org.apache.camel.forage.core.common;
+
+import java.util.Set;
+
+/**
+ * Kind of SPI interface for enhancing exports using <strong>camel forage export (or run)</strong>
+ *
+ * <p>
+ * The ony ability is to add runtime based dependencies. See
+ * {@link org.apache.camel.forage.jdbc.common.DatasourceExportCustomizer} for the usage
+ * </p>
+ */
+public interface ExportCustomizer {
+
+    default boolean isEnabled() {
+        return true;
+    }
+
+    Set<String> resolveRuntimeDependencies(RuntimeType runtime);
+}

--- a/core/forage-core-common/src/main/java/org/apache/camel/forage/core/common/RuntimeType.java
+++ b/core/forage-core-common/src/main/java/org/apache/camel/forage/core/common/RuntimeType.java
@@ -1,0 +1,10 @@
+package org.apache.camel.forage.core.common;
+
+/**
+ * Enum with supported runtimes. Duplicates on org.apache.camel.dsl.jbang.core.common.RuntimeType, but allows us to not
+ * depend on cameljbang here, in commons module.
+ */
+public enum RuntimeType {
+    quarkus,
+    springBoot;
+}

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceCommonExportHelper.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceCommonExportHelper.java
@@ -1,25 +1,9 @@
 package org.apache.camel.forage.jdbc.common;
 
-import java.io.InputStream;
-
 /**
  * Utility class for jdbc configuration value processing and transformation in the Camel Forage framework.
  */
-public final class DataSourceFactoryConfigHelper {
-
-    /**
-     * Regexp for See {@link org.apache.camel.forage.core.util.config.ConfigStore#readPrefixes(InputStream, String)}
-     * to extract all datasource groups from the properties file.
-     *
-     * <p>From properties
-     * <pre>
-     *     ds1.jdbc.url=jdbc:postgresql://localhost:5432/postgres
-     *     ds2.jdbc.url=jdbc:mysql://localhost:3306/test
-     * </pre>
-     *  both <Strong>ds1, ds2</Strong> prefixes are extracted.
-     * </p>
-     * */
-    public static final String JDBC_PREFIXES_REGEXP = "(.+).jdbc\\..*";
+public final class DataSourceCommonExportHelper {
 
     /**
      * Utility method, to translate dbKind into {@link org.apache.camel.forage.jdbc.common.PooledDataSource}.

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/DataSourceBeanFactory.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/DataSourceBeanFactory.java
@@ -10,8 +10,8 @@ import org.apache.camel.forage.core.common.BeanFactory;
 import org.apache.camel.forage.core.common.ServiceLoaderHelper;
 import org.apache.camel.forage.core.jdbc.DataSourceProvider;
 import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.jdbc.common.DataSourceCommonExportHelper;
 import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
-import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigHelper;
 import org.apache.camel.forage.jdbc.jta.MandatoryJtaTransactionPolicy;
 import org.apache.camel.forage.jdbc.jta.NeverJtaTransactionPolicy;
 import org.apache.camel.forage.jdbc.jta.NotSupportedJtaTransactionPolicy;
@@ -76,7 +76,7 @@ public class DataSourceBeanFactory implements BeanFactory {
 
     private synchronized DataSource newDataSource(DataSourceFactoryConfig dataSourceFactoryConfig, String name) {
         final String dataSourceProviderClass =
-                DataSourceFactoryConfigHelper.transformDbKindIntoProviderClass(dataSourceFactoryConfig.dbKind());
+                DataSourceCommonExportHelper.transformDbKindIntoProviderClass(dataSourceFactoryConfig.dbKind());
         LOG.info("Creating DataSource of type {}", dataSourceProviderClass);
 
         final List<ServiceLoader.Provider<DataSourceProvider>> providers = findProviders(DataSourceProvider.class);

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/org/apache/camel/forage/springboot/jdbc/ForageDataSourceAutoConfiguration.java
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/org/apache/camel/forage/springboot/jdbc/ForageDataSourceAutoConfiguration.java
@@ -10,8 +10,8 @@ import org.apache.camel.forage.core.annotations.ForageFactory;
 import org.apache.camel.forage.core.common.ServiceLoaderHelper;
 import org.apache.camel.forage.core.jdbc.DataSourceProvider;
 import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.jdbc.common.DataSourceCommonExportHelper;
 import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
-import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
@@ -111,7 +111,7 @@ public class ForageDataSourceAutoConfiguration implements BeanFactoryAware {
     private synchronized AgroalDataSource newDataSource(DataSourceFactoryConfig dataSourceFactoryConfig, String name) {
         log.debug("Creating new DataSource for name: {} with dbKind: {}", name, dataSourceFactoryConfig.dbKind());
         final String dataSourceProviderClass =
-                DataSourceFactoryConfigHelper.transformDbKindIntoProviderClass(dataSourceFactoryConfig.dbKind());
+                DataSourceCommonExportHelper.transformDbKindIntoProviderClass(dataSourceFactoryConfig.dbKind());
         log.debug("Resolved provider class: {}", dataSourceProviderClass);
 
         final List<ServiceLoader.Provider<DataSourceProvider>> providers = findDataSourceProviders();

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/DataSourceExportHelper.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/DataSourceExportHelper.java
@@ -1,0 +1,84 @@
+package org.apache.camel.forage.plugin;
+
+import java.io.InputStream;
+import org.apache.camel.forage.core.common.RuntimeType;
+
+/**
+ * Utility class for jdbc configuration value processing and transformation in the Camel Forage framework.
+ */
+public final class DataSourceExportHelper {
+
+    /**
+     * Regexp for See {@link org.apache.camel.forage.core.util.config.ConfigStore#readPrefixes(InputStream, String)}
+     * to extract all datasource groups from the properties file.
+     *
+     * <p>From properties
+     * <pre>
+     *     ds1.jdbc.url=jdbc:postgresql://localhost:5432/postgres
+     *     ds2.jdbc.url=jdbc:mysql://localhost:3306/test
+     * </pre>
+     *  both <Strong>ds1, ds2</Strong> prefixes are extracted.
+     * </p>
+     * */
+    public static final String JDBC_PREFIXES_REGEXP = "(.+).jdbc\\..*";
+
+    public static String getDbKindNameForRuntime(String dbKind, RuntimeType runtime) {
+        switch (runtime) {
+            case quarkus -> {
+                if ("postgresql".equals(dbKind)) {
+                    return "postgresql";
+                }
+            }
+            case springBoot -> {
+                if ("postgresql".equals(dbKind)) {
+                    return "postgres";
+                }
+            }
+        }
+
+        return dbKind;
+    }
+
+    /**
+     * Gets the quarkus version from the versions.properties file. (which is populated during buildtime)
+     *
+     * @return the project version
+     */
+    public static String getQuarkusVersion() {
+        return getString("quarkus.version", "Could not determine quarkus version from properties file.");
+    }
+
+    /**
+     * Gets the quarkus version from the versions.properties file. (which is populated during buildtime)
+     *
+     * @return the project version
+     */
+    public static String geProjectVersion() {
+        return getString("jdbc.dependency.version", "Could not determine project version from properties file.");
+    }
+
+    /**
+     * Reads property from the file versions.properties (which contains build time resolved versions)
+     */
+    private static String getString(String key, String error) {
+        try {
+            java.util.Properties properties = new java.util.Properties();
+            try (InputStream is = DataSourceExportHelper.class
+                    .getClassLoader()
+                    .getResourceAsStream("datasource-command.properties")) {
+                if (is != null) {
+                    properties.load(is);
+                    String version = properties.getProperty(key);
+                    if (version != null && !version.trim().isEmpty()) {
+                        return version;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(error, e);
+        }
+
+        // Ultimate fallback
+        return null;
+    }
+}

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/datasource/DatasourceExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/datasource/DatasourceExportCustomizer.java
@@ -1,0 +1,84 @@
+package org.apache.camel.forage.plugin.datasource;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.camel.forage.core.common.ExportCustomizer;
+import org.apache.camel.forage.core.common.RuntimeType;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
+import org.apache.camel.forage.plugin.DataSourceExportHelper;
+
+/**
+ * Implementation of export customizer for datasource properties.
+ *
+ * <p>
+ * Adds quarkus or spring-boot runtime dependencies, thus making export command less verbose.
+ * </p>
+ */
+public class DatasourceExportCustomizer implements ExportCustomizer {
+
+    @Override
+    public Set<String> resolveRuntimeDependencies(RuntimeType runtime) {
+        Set<String> dependencies = new HashSet<>();
+
+        switch (runtime) {
+            case quarkus -> {
+                listDependencies(
+                        dependencies,
+                        Arrays.asList("mvn:org.apache.camel.forage:forage-quarkus-jdbc-configurer:"
+                                + DataSourceExportHelper.geProjectVersion()),
+                        "mvn:io.quarkus:quarkus-jdbc-",
+                        ":" + DataSourceExportHelper.getQuarkusVersion(),
+                        runtime);
+            }
+            case springBoot -> {
+                listDependencies(
+                        dependencies,
+                        Arrays.asList(
+                                "mvn:org.apache.camel.forage:forage-jdbc-starter:"
+                                        + DataSourceExportHelper.geProjectVersion(),
+                                "mvn:org.apache.camel.forage:forage-jdbc:" + DataSourceExportHelper.geProjectVersion()),
+                        "mvn:org.apache.camel.forage:forage-jdbc-",
+                        ":" + DataSourceExportHelper.geProjectVersion(),
+                        runtime);
+            }
+        }
+
+        return dependencies;
+    }
+
+    private static void listDependencies(
+            Set<String> dependencies,
+            List<String> newDependencies,
+            String depPrefix,
+            String depVersion,
+            RuntimeType runtime) {
+        dependencies.addAll(newDependencies);
+
+        try {
+            DataSourceFactoryConfig config = new DataSourceFactoryConfig();
+            Set<String> prefixes =
+                    ConfigStore.getInstance().readPrefixes(config, DataSourceExportHelper.JDBC_PREFIXES_REGEXP);
+
+            if (!prefixes.isEmpty()) {
+                for (String name : prefixes) {
+                    DataSourceFactoryConfig dsFactoryConfig = new DataSourceFactoryConfig(name);
+                    // todoo get quarkus version
+                    dependencies.add(depPrefix
+                            + DataSourceExportHelper.getDbKindNameForRuntime(dsFactoryConfig.dbKind(), runtime)
+                            + depVersion);
+                }
+            } else {
+                // todo get quarkus version
+                dependencies.add(depPrefix
+                        + DataSourceExportHelper.getDbKindNameForRuntime(config.dbKind(), runtime)
+                        + depVersion);
+            }
+
+        } catch (Exception ex) {
+            // todo log error
+        }
+    }
+}

--- a/tooling/camel-jbang-plugin-forage/src/main/resources/datasource-command.properties
+++ b/tooling/camel-jbang-plugin-forage/src/main/resources/datasource-command.properties
@@ -1,1 +1,2 @@
 jdbc.dependency.version=@project.version@
+quarkus.version=@quarkus.version@


### PR DESCRIPTION
Export and Run commands via forage.

You can now run 
```
camel forage export forage-datasource-factory.properties Route.java  --runtime=quarkus
camel forage run forage-datasource-factory.properties Route.java  --runtime=quarkus
```
or
```
camel forage export  forage-datasource-factory.properties Route.java  --runtime=spring-boot
camel forage run  forage-datasource-factory.properties Route.java  --runtime=spring-boot
```
without defining dependencies like:
```
camel run forage-datasource-factory.properties Route.java \
  ---dep=mvn:org.apache.camel.forage:forage-jdbc-factories:1.0-SNAPSHOT \
  --dep=mvn:org.apache.camel.forage:forage-jdbc-postgres:1.0-SNAPSHOT
```

Modified forage-examples will follow in different PR.

**How it works?**
Both coommands are using unmodified commands from camel-jbang + are adding runtime dependencies via `PluginExporter`.  Dependencies are resolved based on the property files (coming from user) - mainly **dbKind**.