### PR TITLE
Add Transaction support for plain Camel and Camel Spring Boot

### DIFF
--- a/library/jdbc/forage-jdbc-common/pom.xml
+++ b/library/jdbc/forage-jdbc-common/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>forage-core-jdbc</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jta</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.agroal</groupId>
@@ -33,6 +37,21 @@
             <groupId>io.agroal</groupId>
             <artifactId>agroal-pool</artifactId>
             <version>${agroal.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.agroal</groupId>
+            <artifactId>agroal-narayana</artifactId>
+            <version>${agroal.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.jta</groupId>
+            <artifactId>narayana-jta</artifactId>
+            <version>${narayana.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.narayana.jta</groupId>
+            <artifactId>jdbc</artifactId>
+            <version>${narayana.version}</version>
         </dependency>
 
         <dependency>

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfig.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfig.java
@@ -124,4 +124,90 @@ public class DataSourceFactoryConfig implements Config {
                 .map(Integer::parseInt)
                 .orElse(30);
     }
+
+    public boolean transactionEnabled() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_ENABLED.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    public String transactionNodeId() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_NODE_ID.asNamed(prefix))
+                .orElse(null);
+    }
+
+    public String transactionObjectStoreId() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_OBJECT_STORE_ID.asNamed(prefix))
+                .orElse(null);
+    }
+
+    public boolean transactionEnableRecovery() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_ENABLE_RECOVERY.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    public String transactionRecoveryModules() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_RECOVERY_MODULES.asNamed(prefix))
+                .orElse("com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule,"
+                        + "com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule");
+    }
+
+    public String transactionExpiryScanners() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_EXPIRY_SCANNERS.asNamed(prefix))
+                .orElse("com.arjuna.ats.internal.arjuna.recovery.ExpiredTransactionStatusManagerScanner");
+    }
+
+    public String transactionXaResourceOrphanFilters() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_XA_RESOURCE_ORPHAN_FILTERS.asNamed(prefix))
+                .orElse(
+                        "com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter,"
+                                + "com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter,"
+                                + "com.arjuna.ats.internal.jta.recovery.arjunacore.JTAActionStatusServiceXAResourceOrphanFilter");
+    }
+
+    public String transactionObjectStoreDirectory() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_OBJECT_STORE_DIRECTORY.asNamed(prefix))
+                .orElse("ObjectStore");
+    }
+
+    public String transactionObjectStoreType() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_OBJECT_STORE_TYPE.asNamed(prefix))
+                .orElse("file-system");
+    }
+
+    public String transactionObjectStoreDataSource() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_OBJECT_STORE_DATASOURCE.asNamed(prefix))
+                .orElse(null);
+    }
+
+    public boolean transactionObjectStoreCreateTable() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_OBJECT_STORE_CREATE_TABLE.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    public boolean transactionObjectStoreDropTable() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_OBJECT_STORE_DROP_TABLE.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    public String transactionObjectStoreTablePrefix() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.TRANSACTION_OBJECT_STORE_TABLE_PREFIX.asNamed(prefix))
+                .orElse("forage_");
+    }
 }

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfigEntries.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfigEntries.java
@@ -39,6 +39,33 @@ public class DataSourceFactoryConfigEntries extends ConfigEntries {
     public static final ConfigModule PROVIDER_DATASOURCE_CLASS =
             ConfigModule.of(DataSourceFactoryConfig.class, "provider.datasource.class");
 
+    public static final ConfigModule TRANSACTION_ENABLED =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.enabled");
+    public static final ConfigModule TRANSACTION_NODE_ID =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.node.id");
+    public static final ConfigModule TRANSACTION_OBJECT_STORE_ID =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.id");
+    public static final ConfigModule TRANSACTION_ENABLE_RECOVERY =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.enable.recovery");
+    public static final ConfigModule TRANSACTION_RECOVERY_MODULES =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.recovery.modules");
+    public static final ConfigModule TRANSACTION_EXPIRY_SCANNERS =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.expiry.scanners");
+    public static final ConfigModule TRANSACTION_XA_RESOURCE_ORPHAN_FILTERS =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.xa.resource.orphan.filters");
+    public static final ConfigModule TRANSACTION_OBJECT_STORE_DIRECTORY =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.directory");
+    public static final ConfigModule TRANSACTION_OBJECT_STORE_TYPE =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.type");
+    public static final ConfigModule TRANSACTION_OBJECT_STORE_DATASOURCE =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.datasource");
+    public static final ConfigModule TRANSACTION_OBJECT_STORE_CREATE_TABLE =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.create.table");
+    public static final ConfigModule TRANSACTION_OBJECT_STORE_DROP_TABLE =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.drop.table");
+    public static final ConfigModule TRANSACTION_OBJECT_STORE_TABLE_PREFIX =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.table.prefix");
+
     private static final Map<ConfigModule, ConfigEntry> CONFIG_MODULES = new ConcurrentHashMap<>();
 
     static {
@@ -60,6 +87,19 @@ public class DataSourceFactoryConfigEntries extends ConfigEntries {
         CONFIG_MODULES.put(IDLE_VALIDATION_TIMEOUT_MINUTES, ConfigEntry.fromModule());
         CONFIG_MODULES.put(TRANSACTION_TIMEOUT_SECONDS, ConfigEntry.fromModule());
         CONFIG_MODULES.put(PROVIDER_DATASOURCE_CLASS, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_ENABLED, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_NODE_ID, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_ID, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_ENABLE_RECOVERY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_RECOVERY_MODULES, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_EXPIRY_SCANNERS, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_XA_RESOURCE_ORPHAN_FILTERS, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_DIRECTORY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_TYPE, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_DATASOURCE, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_CREATE_TABLE, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_DROP_TABLE, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_TABLE_PREFIX, ConfigEntry.fromModule());
     }
 
     public static Map<ConfigModule, ConfigEntry> entries() {

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/transactions/TransactionConfiguration.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/transactions/TransactionConfiguration.java
@@ -1,0 +1,122 @@
+package org.apache.camel.forage.jdbc.common.transactions;
+
+import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
+import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
+import com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
+import io.agroal.narayana.LocalXAResource;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransactionConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionConfiguration.class);
+
+    private final DataSourceFactoryConfig config;
+    private String transactionNodeId;
+
+    public TransactionConfiguration(DataSourceFactoryConfig config, String id) {
+        this.config = config;
+        if (config.transactionNodeId() == null) {
+            transactionNodeId = id;
+        } else {
+            transactionNodeId = config.transactionNodeId();
+        }
+        log.info("TransactionConfiguration initialized with nodeId: {}", transactionNodeId);
+    }
+
+    public void initializeNarayana() {
+        log.info("Initializing Narayana transaction manager with nodeId: {}", transactionNodeId);
+        try {
+            configureCoreEnvironment();
+        } catch (CoreEnvironmentBeanException e) {
+            log.error("Failed to configure core environment for transaction manager", e);
+            throw new RuntimeException(e);
+        }
+        configureObjectStore();
+        configureCoordinator();
+        configureRecovery();
+        configureJTA();
+        log.info("Narayana transaction manager initialization completed");
+    }
+
+    private void configureCoreEnvironment() throws CoreEnvironmentBeanException {
+        log.debug("Configuring core environment with nodeId: {}", transactionNodeId);
+        CoreEnvironmentBean coreBean = BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class);
+        coreBean.setNodeIdentifier(transactionNodeId);
+        log.debug("Core environment configured successfully");
+    }
+
+    private void configureObjectStore() {
+        log.debug(
+                "Configuring object store with type: {} and directory: {}",
+                config.transactionObjectStoreType(),
+                config.transactionObjectStoreDirectory());
+        ObjectStoreEnvironmentBean osBean = BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class);
+        if ("file-system".equals(config.transactionObjectStoreType())) {
+            osBean.setObjectStoreDir(config.transactionObjectStoreDirectory());
+        }
+
+        // TODO Handle jdbc case, a datasource has to be created for this use case
+        //        if ("jdbc".equals(config.transactionObjectStoreType())) {
+        //            osBean.setObjectStoreType(JDBCStore.class.getName());
+        //            osBean.setJdbcDataSource(objectStorageDataSource);
+        //
+        //            osBean.setCreateTable(config.transactionObjectStoreCreateTable());
+        //            osBean.setDropTable(config.transactionObjectStoreDropTable());
+        //            osBean.setTablePrefix(config.transactionObjectStoreTablePrefix());
+        //        }
+        log.debug("Object store configured successfully");
+    }
+
+    private void configureCoordinator() {
+        log.debug("Configuring coordinator with timeout: {} seconds", config.transactionTimeoutSeconds());
+        BeanPopulator.getDefaultInstance(CoordinatorEnvironmentBean.class)
+                .setDefaultTimeout(config.transactionTimeoutSeconds());
+        log.debug("Coordinator configured successfully");
+    }
+
+    private void configureRecovery() {
+        if (config.transactionEnableRecovery()) {
+            log.debug(
+                    "Configuring recovery with modules: {} and expiry scanners: {}",
+                    config.transactionRecoveryModules(),
+                    config.transactionExpiryScanners());
+            BeanPopulator.getDefaultInstance(RecoveryEnvironmentBean.class)
+                    .setRecoveryModuleClassNames(
+                            Arrays.stream(config.transactionRecoveryModules().split(","))
+                                    .map(String::trim)
+                                    .toList());
+            BeanPopulator.getDefaultInstance(RecoveryEnvironmentBean.class)
+                    .setExpiryScannerClassNames(
+                            Arrays.stream(config.transactionExpiryScanners().split(","))
+                                    .map(String::trim)
+                                    .toList());
+            log.debug("Recovery configured successfully");
+        } else {
+            log.debug("Recovery disabled in configuration");
+        }
+    }
+
+    private void configureJTA() {
+        log.debug(
+                "Configuring JTA with recovery nodes: {} and orphan filters: {}",
+                transactionNodeId,
+                config.transactionXaResourceOrphanFilters());
+        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class).setXaRecoveryNodes(List.of(transactionNodeId));
+        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class)
+                .setLastResourceOptimisationInterface(LocalXAResource.class);
+        BeanPopulator.getDefaultInstance(JTAEnvironmentBean.class)
+                .setXaResourceOrphanFilterClassNames(Arrays.stream(
+                                config.transactionXaResourceOrphanFilters().split(","))
+                        .map(String::trim)
+                        .toList());
+        log.debug("JTA configured successfully");
+    }
+}

--- a/library/jdbc/forage-jdbc-db2/src/main/java/org/apache/camel/forage/jdbc/db2/Db2Jdbc.java
+++ b/library/jdbc/forage-jdbc-db2/src/main/java/org/apache/camel/forage/jdbc/db2/Db2Jdbc.java
@@ -1,6 +1,7 @@
 package org.apache.camel.forage.jdbc.db2;
 
 import com.ibm.db2.jcc.DB2Driver;
+import com.ibm.db2.jcc.DB2XADataSource;
 import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.jdbc.common.PooledDataSource;
 
@@ -16,7 +17,11 @@ public class Db2Jdbc extends PooledDataSource {
 
     @Override
     protected Class getConnectionProviderClass() {
-        return DB2Driver.class;
+        if (getConfig().transactionEnabled()) {
+            return DB2XADataSource.class;
+        } else {
+            return DB2Driver.class;
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc-h2/src/main/java/org/apache/camel/forage/jdbc/h2/H2Jdbc.java
+++ b/library/jdbc/forage-jdbc-h2/src/main/java/org/apache/camel/forage/jdbc/h2/H2Jdbc.java
@@ -3,6 +3,7 @@ package org.apache.camel.forage.jdbc.h2;
 import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.jdbc.common.PooledDataSource;
 import org.h2.Driver;
+import org.h2.jdbcx.JdbcDataSource;
 
 /**
  * H2 Database implementation extending PooledJdbc.
@@ -16,7 +17,11 @@ public class H2Jdbc extends PooledDataSource {
 
     @Override
     protected Class getConnectionProviderClass() {
-        return Driver.class;
+        if (getConfig().transactionEnabled()) {
+            return JdbcDataSource.class;
+        } else {
+            return Driver.class;
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc-hsqldb/src/main/java/org/apache/camel/forage/jdbc/hsqldb/HsqldbJdbc.java
+++ b/library/jdbc/forage-jdbc-hsqldb/src/main/java/org/apache/camel/forage/jdbc/hsqldb/HsqldbJdbc.java
@@ -3,6 +3,7 @@ package org.apache.camel.forage.jdbc.hsqldb;
 import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.jdbc.common.PooledDataSource;
 import org.hsqldb.jdbc.JDBCDriver;
+import org.hsqldb.jdbc.pool.JDBCXADataSource;
 
 /**
  * HSQLDB implementation extending PooledJdbc.
@@ -16,7 +17,11 @@ public class HsqldbJdbc extends PooledDataSource {
 
     @Override
     protected Class getConnectionProviderClass() {
-        return JDBCDriver.class;
+        if (getConfig().transactionEnabled()) {
+            return JDBCXADataSource.class;
+        } else {
+            return JDBCDriver.class;
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc-mariadb/src/main/java/org/apache/camel/forage/jdbc/mariadb/MariadbJdbc.java
+++ b/library/jdbc/forage-jdbc-mariadb/src/main/java/org/apache/camel/forage/jdbc/mariadb/MariadbJdbc.java
@@ -3,6 +3,7 @@ package org.apache.camel.forage.jdbc.mariadb;
 import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.jdbc.common.PooledDataSource;
 import org.mariadb.jdbc.Driver;
+import org.mariadb.jdbc.MariaDbDataSource;
 
 /**
  * MariaDB implementation extending PooledJdbc.
@@ -16,7 +17,11 @@ public class MariadbJdbc extends PooledDataSource {
 
     @Override
     protected Class getConnectionProviderClass() {
-        return Driver.class;
+        if (getConfig().transactionEnabled()) {
+            return MariaDbDataSource.class;
+        } else {
+            return Driver.class;
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc-mssql/src/main/java/org/apache/camel/forage/jdbc/mssql/MssqlJdbc.java
+++ b/library/jdbc/forage-jdbc-mssql/src/main/java/org/apache/camel/forage/jdbc/mssql/MssqlJdbc.java
@@ -1,6 +1,7 @@
 package org.apache.camel.forage.jdbc.mssql;
 
 import com.microsoft.sqlserver.jdbc.SQLServerDriver;
+import com.microsoft.sqlserver.jdbc.SQLServerXADataSource;
 import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.jdbc.common.PooledDataSource;
 
@@ -16,7 +17,11 @@ public class MssqlJdbc extends PooledDataSource {
 
     @Override
     protected Class getConnectionProviderClass() {
-        return SQLServerDriver.class;
+        if (getConfig().transactionEnabled()) {
+            return SQLServerXADataSource.class;
+        } else {
+            return SQLServerDriver.class;
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc-mysql/src/main/java/org/apache/camel/forage/jdbc/mysql/MysqlJdbc.java
+++ b/library/jdbc/forage-jdbc-mysql/src/main/java/org/apache/camel/forage/jdbc/mysql/MysqlJdbc.java
@@ -1,6 +1,7 @@
 package org.apache.camel.forage.jdbc.mysql;
 
 import com.mysql.cj.jdbc.Driver;
+import com.mysql.cj.jdbc.MysqlXADataSource;
 import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.jdbc.common.PooledDataSource;
 
@@ -16,7 +17,11 @@ public class MysqlJdbc extends PooledDataSource {
 
     @Override
     protected Class getConnectionProviderClass() {
-        return Driver.class;
+        if (getConfig().transactionEnabled()) {
+            return MysqlXADataSource.class;
+        } else {
+            return Driver.class;
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc-oracle/src/main/java/org/apache/camel/forage/jdbc/oracle/OracleJdbc.java
+++ b/library/jdbc/forage-jdbc-oracle/src/main/java/org/apache/camel/forage/jdbc/oracle/OracleJdbc.java
@@ -1,6 +1,7 @@
 package org.apache.camel.forage.jdbc.oracle;
 
 import oracle.jdbc.OracleDriver;
+import oracle.jdbc.xa.OracleXADataSource;
 import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.jdbc.common.PooledDataSource;
 
@@ -16,7 +17,11 @@ public class OracleJdbc extends PooledDataSource {
 
     @Override
     protected Class getConnectionProviderClass() {
-        return OracleDriver.class;
+        if (getConfig().transactionEnabled()) {
+            return OracleXADataSource.class;
+        } else {
+            return OracleDriver.class;
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc-postgres/src/main/java/org/apache/camel/forage/jdbc/postgres/PostgresJdbc.java
+++ b/library/jdbc/forage-jdbc-postgres/src/main/java/org/apache/camel/forage/jdbc/postgres/PostgresJdbc.java
@@ -3,6 +3,7 @@ package org.apache.camel.forage.jdbc.postgres;
 import org.apache.camel.forage.core.annotations.ForageBean;
 import org.apache.camel.forage.jdbc.common.PooledDataSource;
 import org.postgresql.Driver;
+import org.postgresql.xa.PGXADataSource;
 
 /**
  * PostgreSQL implementation extending PooledJdbc.
@@ -16,7 +17,11 @@ public class PostgresJdbc extends PooledDataSource {
 
     @Override
     protected Class getConnectionProviderClass() {
-        return Driver.class;
+        if (getConfig().transactionEnabled()) {
+            return PGXADataSource.class;
+        } else {
+            return Driver.class;
+        }
     }
 
     @Override

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/DataSourceBeanFactory.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/DataSourceBeanFactory.java
@@ -12,6 +12,12 @@ import org.apache.camel.forage.core.jdbc.DataSourceProvider;
 import org.apache.camel.forage.core.util.config.ConfigStore;
 import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
 import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfigHelper;
+import org.apache.camel.forage.jdbc.jta.MandatoryJtaTransactionPolicy;
+import org.apache.camel.forage.jdbc.jta.NeverJtaTransactionPolicy;
+import org.apache.camel.forage.jdbc.jta.NotSupportedJtaTransactionPolicy;
+import org.apache.camel.forage.jdbc.jta.RequiredJtaTransactionPolicy;
+import org.apache.camel.forage.jdbc.jta.RequiresNewJtaTransactionPolicy;
+import org.apache.camel.forage.jdbc.jta.SupportsJtaTransactionPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +38,15 @@ public class DataSourceBeanFactory implements BeanFactory {
 
         DataSourceFactoryConfig config = new DataSourceFactoryConfig();
         Set<String> prefixes = ConfigStore.getInstance().readPrefixes(config, "(.+).jdbc\\..*");
+
+        if (config.transactionEnabled()) {
+            camelContext.getRegistry().bind("PROPAGATION_REQUIRED", new RequiredJtaTransactionPolicy());
+            camelContext.getRegistry().bind("MANDATORY", new MandatoryJtaTransactionPolicy());
+            camelContext.getRegistry().bind("NEVER", new NeverJtaTransactionPolicy());
+            camelContext.getRegistry().bind("NOT_SUPPORTED", new NotSupportedJtaTransactionPolicy());
+            camelContext.getRegistry().bind("REQUIRES_NEW", new RequiresNewJtaTransactionPolicy());
+            camelContext.getRegistry().bind("SUPPORTS", new SupportsJtaTransactionPolicy());
+        }
 
         if (!prefixes.isEmpty()) {
             for (String name : prefixes) {

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/MandatoryJtaTransactionPolicy.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/MandatoryJtaTransactionPolicy.java
@@ -1,0 +1,13 @@
+package org.apache.camel.forage.jdbc.jta;
+
+public final class MandatoryJtaTransactionPolicy extends TransactionalJtaTransactionPolicy {
+
+    @Override
+    public void run(final Runnable runnable) throws Throwable {
+        if (!hasActiveTransaction()) {
+            throw new IllegalStateException(
+                    "Policy 'PROPAGATION_MANDATORY' is configured but no active transaction was found!");
+        }
+        runWithTransaction(runnable, false);
+    }
+}

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/NeverJtaTransactionPolicy.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/NeverJtaTransactionPolicy.java
@@ -1,0 +1,14 @@
+package org.apache.camel.forage.jdbc.jta;
+
+public final class NeverJtaTransactionPolicy extends TransactionalJtaTransactionPolicy {
+
+    @Override
+    public void run(final Runnable runnable) throws Throwable {
+        if (hasActiveTransaction()) {
+            throw new IllegalStateException(
+                    "Policy 'PROPAGATION_NEVER' is configured but an active transaction was found!");
+        }
+
+        runnable.run();
+    }
+}

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/NotSupportedJtaTransactionPolicy.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/NotSupportedJtaTransactionPolicy.java
@@ -1,0 +1,17 @@
+package org.apache.camel.forage.jdbc.jta;
+
+import jakarta.transaction.Transaction;
+
+public final class NotSupportedJtaTransactionPolicy extends TransactionalJtaTransactionPolicy {
+
+    @Override
+    public void run(final Runnable runnable) throws Throwable {
+        Transaction suspendedTransaction = null;
+        try {
+            suspendedTransaction = suspendTransaction();
+            runnable.run();
+        } finally {
+            resumeTransaction(suspendedTransaction);
+        }
+    }
+}

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/RequiredJtaTransactionPolicy.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/RequiredJtaTransactionPolicy.java
@@ -1,0 +1,9 @@
+package org.apache.camel.forage.jdbc.jta;
+
+public final class RequiredJtaTransactionPolicy extends TransactionalJtaTransactionPolicy {
+
+    @Override
+    public void run(final Runnable runnable) throws Throwable {
+        runWithTransaction(runnable, !hasActiveTransaction());
+    }
+}

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/RequiresNewJtaTransactionPolicy.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/RequiresNewJtaTransactionPolicy.java
@@ -1,0 +1,17 @@
+package org.apache.camel.forage.jdbc.jta;
+
+import jakarta.transaction.Transaction;
+
+public final class RequiresNewJtaTransactionPolicy extends TransactionalJtaTransactionPolicy {
+
+    @Override
+    public void run(final Runnable runnable) throws Throwable {
+        Transaction suspendedTransaction = null;
+        try {
+            suspendedTransaction = suspendTransaction();
+            runWithTransaction(runnable, true);
+        } finally {
+            resumeTransaction(suspendedTransaction);
+        }
+    }
+}

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/SupportsJtaTransactionPolicy.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/SupportsJtaTransactionPolicy.java
@@ -1,0 +1,9 @@
+package org.apache.camel.forage.jdbc.jta;
+
+public final class SupportsJtaTransactionPolicy extends TransactionalJtaTransactionPolicy {
+
+    @Override
+    public void run(final Runnable runnable) throws Throwable {
+        runnable.run();
+    }
+}

--- a/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/TransactionalJtaTransactionPolicy.java
+++ b/library/jdbc/forage-jdbc/src/main/java/org/apache/camel/forage/jdbc/jta/TransactionalJtaTransactionPolicy.java
@@ -1,0 +1,82 @@
+package org.apache.camel.forage.jdbc.jta;
+
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import org.apache.camel.jta.JtaTransactionPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class TransactionalJtaTransactionPolicy extends JtaTransactionPolicy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TransactionalJtaTransactionPolicy.class);
+
+    private jakarta.transaction.TransactionManager transactionManager =
+            com.arjuna.ats.jta.TransactionManager.transactionManager();
+
+    protected void runWithTransaction(final Runnable runnable, final boolean isNew) throws Throwable {
+        if (isNew) {
+            begin();
+        }
+        try {
+            runnable.run();
+        } catch (Throwable e) {
+            rollback(isNew);
+            throw e;
+        }
+        if (isNew) {
+            commit();
+        }
+    }
+
+    private void begin() throws Exception {
+        transactionManager.begin();
+    }
+
+    private void commit() throws Exception {
+        try {
+            transactionManager.commit();
+        } catch (HeuristicMixedException | HeuristicRollbackException | RollbackException | SystemException e) {
+            throw new RuntimeException("Unable to commit transaction", e);
+        } catch (Exception | Error e) {
+            rollback(true);
+            throw e;
+        }
+    }
+
+    protected final void rollback(boolean isNew) throws Exception {
+        try {
+            if (isNew) {
+                transactionManager.rollback();
+            } else {
+                transactionManager.setRollbackOnly();
+            }
+        } catch (Throwable e) {
+            LOG.warn("Could not rollback transaction!", e);
+        }
+    }
+
+    protected final jakarta.transaction.Transaction suspendTransaction() throws Exception {
+        return transactionManager.suspend();
+    }
+
+    protected final void resumeTransaction(final Transaction suspendedTransaction) {
+        if (suspendedTransaction == null) {
+            return;
+        }
+
+        try {
+            transactionManager.resume(suspendedTransaction);
+        } catch (Throwable e) {
+            LOG.warn("Could not resume transaction!", e);
+        }
+    }
+
+    protected final boolean hasActiveTransaction() throws Exception {
+        return transactionManager.getStatus() != Status.STATUS_MARKED_ROLLBACK
+                && transactionManager.getStatus() != Status.STATUS_NO_TRANSACTION;
+    }
+}

--- a/library/jdbc/spring-boot/forage-jdbc-starter/pom.xml
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>forage-jdbc-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-spring</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/org/apache/camel/forage/springboot/jdbc/ConditionalOnForageProperty.java
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/org/apache/camel/forage/springboot/jdbc/ConditionalOnForageProperty.java
@@ -1,0 +1,76 @@
+package org.apache.camel.forage.springboot.jdbc;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apache.camel.forage.core.util.config.Config;
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional @Conditional} that checks if a Forage configuration property
+ * matches the expected value. Conditionally enables Spring components based on
+ * Forage configuration properties in any configuration (default or prefixed).
+ *
+ * <p>Example usage:
+ * <pre class="code">
+ * // Check if transaction is enabled in DataSourceFactoryConfig
+ * &#64;Configuration
+ * &#64;ConditionalOnForageProperty(
+ *     configClass = DataSourceFactoryConfig.class,
+ *     property = "jdbc.transaction.enabled",
+ *     havingValue = "true"
+ * )
+ * &#64;EnableTransactionManagement
+ * public class TransactionConfiguration {
+ *     // Configuration beans that should only exist when transactions are enabled
+ * }
+ * </pre>
+ *
+ * @see ForagePropertyCondition
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(ForagePropertyCondition.class)
+public @interface ConditionalOnForageProperty {
+
+    /**
+     * The Forage configuration class that contains the property to check.
+     * Must implement {@link Config}.
+     *
+     * @return the configuration class
+     */
+    Class<? extends Config> configClass();
+
+    /**
+     * The property name as defined in the configuration's ConfigEntries.
+     * This should match the property name used in ConfigModule.of() calls.
+     * For example: "jdbc.transaction.enabled" for DataSourceFactoryConfig.
+     *
+     * @return the property name
+     */
+    String property();
+
+    /**
+     * The expected value for the property. If not specified, the condition
+     * will match if the property exists and is not null/empty.
+     *
+     * <p>For boolean properties, use "true" or "false".
+     * For other types, the string representation will be compared.
+     *
+     * @return the expected value
+     */
+    String havingValue() default "";
+
+    /**
+     * Whether to match when the property does NOT equal the havingValue.
+     * When true, the condition matches when the property value is different
+     * from havingValue (or when havingValue is not specified, when the
+     * property is null/empty).
+     *
+     * @return true to negate the condition
+     */
+    boolean matchIfMissing() default false;
+}

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/org/apache/camel/forage/springboot/jdbc/ForagePropertyCondition.java
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/org/apache/camel/forage/springboot/jdbc/ForagePropertyCondition.java
@@ -1,0 +1,180 @@
+package org.apache.camel.forage.springboot.jdbc;
+
+import java.lang.reflect.Constructor;
+import java.util.Set;
+import org.apache.camel.forage.core.util.config.Config;
+import org.apache.camel.forage.core.util.config.ConfigModule;
+import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+/**
+ * Condition that matches when a specific ConfigModule property matches the expected criteria.
+ * This condition leverages the existing ConfigModule and ConfigStore infrastructure to provide
+ * type-safe property access without reflection.
+ *
+ * <p>The condition logic:
+ * <ul>
+ * <li>If a specific prefix is provided, the ConfigModule is converted to use that prefix</li>
+ * <li>If no prefix is provided and checkAllConfigurations=true, checks all available configurations</li>
+ * <li>If no prefix is provided and checkAllConfigurations=false, checks only default configuration</li>
+ * <li>Uses ConfigStore.get() to retrieve values directly without reflection</li>
+ * <li>Compares the result with the expected value or checks for existence if no value specified</li>
+ * </ul>
+ *
+ * @see ConditionalOnForageProperty
+ * @see ConfigModule
+ * @see ConfigStore
+ */
+public class ForagePropertyCondition extends SpringBootCondition {
+
+    private static final Logger log = LoggerFactory.getLogger(ForagePropertyCondition.class);
+
+    @Override
+    public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        AnnotationAttributes attributes = AnnotationAttributes.fromMap(
+                metadata.getAnnotationAttributes(ConditionalOnForageProperty.class.getName()));
+
+        if (attributes == null) {
+            return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                    .because("annotation not found"));
+        }
+
+        Class<? extends Config> configClass = attributes.getClass("configClass");
+        String property = attributes.getString("property");
+        String havingValue = attributes.getString("havingValue");
+        boolean matchIfMissing = attributes.getBoolean("matchIfMissing");
+
+        if (configClass == null || !StringUtils.hasText(property)) {
+            return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                    .because("configClass and property must be specified"));
+        }
+
+        boolean hasExpectedValue = StringUtils.hasText(havingValue);
+
+        try {
+            // This is pretty early in the life cycle, the Config class may not be initialized
+            configClass.getDeclaredConstructor().newInstance();
+            // Create the ConfigModule from class and property name
+            ConfigModule configModule = ConfigModule.of(configClass, property);
+
+            return checkAllAvailableConfigurations(configModule, havingValue, hasExpectedValue, matchIfMissing);
+        } catch (Exception e) {
+            log.warn("Error evaluating ForagePropertyCondition for {}.{}", configClass.getSimpleName(), property, e);
+            return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                    .because("error occurred while checking configuration: " + e.getMessage()));
+        }
+    }
+
+    private ConditionOutcome checkAllAvailableConfigurations(
+            ConfigModule configModule, String havingValue, boolean hasExpectedValue, boolean matchIfMissing) {
+
+        log.debug("Checking ConfigModule {} for any available configuration", configModule.name());
+
+        try {
+            // Check default configuration first
+            String defaultPropertyValue =
+                    ConfigStore.getInstance().get(configModule).orElse(null);
+            boolean defaultMatches =
+                    evaluatePropertyValue(defaultPropertyValue, havingValue, hasExpectedValue, matchIfMissing);
+
+            log.debug(
+                    "Default configuration ConfigModule {} = {}, matches = {}",
+                    configModule.name(),
+                    defaultPropertyValue,
+                    defaultMatches);
+
+            if (defaultMatches) {
+                return ConditionOutcome.match(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                        .foundExactly("property '" + configModule.name() + "' matches criteria"));
+            }
+
+            // Check prefixed configurations
+            Config tempConfig = createConfigInstance(configModule.config(), null);
+            Set<String> prefixes = ConfigStore.getInstance().readPrefixes(tempConfig, "(.+)\\..*");
+
+            log.debug("Found {} prefixes for configuration checking: {}", prefixes.size(), prefixes);
+
+            for (String prefix : prefixes) {
+                try {
+                    ConfigModule prefixedModule = configModule.asNamed(prefix);
+                    String propertyValue =
+                            ConfigStore.getInstance().get(prefixedModule).orElse(null);
+                    boolean matches =
+                            evaluatePropertyValue(propertyValue, havingValue, hasExpectedValue, matchIfMissing);
+
+                    log.debug(
+                            "ConfigModule {} for prefix '{}' = {}, matches = {}",
+                            configModule.name(),
+                            prefix,
+                            propertyValue,
+                            matches);
+
+                    if (matches) {
+                        return ConditionOutcome.match(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                                .foundExactly("property '" + configModule.name() + "' matches criteria for prefix '"
+                                        + prefix + "'"));
+                    }
+                } catch (Exception e) {
+                    log.debug(
+                            "Failed to check ConfigModule {} for prefix '{}': {}",
+                            configModule.name(),
+                            prefix,
+                            e.getMessage());
+                }
+            }
+
+            // No match found in any configuration
+            if (matchIfMissing) {
+                return ConditionOutcome.match(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                        .foundExactly("property '" + configModule.name() + "' not found and matchIfMissing=true"));
+            } else {
+                return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                        .because(
+                                "property '" + configModule.name() + "' does not match criteria in any configuration"));
+            }
+
+        } catch (Exception e) {
+            log.debug("Failed to check ConfigModule {}: {}", configModule.name(), e.getMessage());
+
+            if (matchIfMissing) {
+                return ConditionOutcome.match(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                        .foundExactly("error checking configurations and matchIfMissing=true"));
+            } else {
+                return ConditionOutcome.noMatch(ConditionMessage.forCondition(ConditionalOnForageProperty.class)
+                        .because("error checking configurations: " + e.getMessage()));
+            }
+        }
+    }
+
+    private Config createConfigInstance(Class<? extends Config> configClass, String prefix) throws Exception {
+        if (prefix != null) {
+            Constructor<? extends Config> constructor = configClass.getConstructor(String.class);
+            return constructor.newInstance(prefix);
+        } else {
+            Constructor<? extends Config> constructor = configClass.getConstructor();
+            return constructor.newInstance();
+        }
+    }
+
+    private boolean evaluatePropertyValue(
+            String propertyValue, String havingValue, boolean hasExpectedValue, boolean matchIfMissing) {
+        if (propertyValue == null) {
+            return matchIfMissing;
+        }
+
+        if (!hasExpectedValue) {
+            return StringUtils.hasText(propertyValue);
+        }
+
+        boolean matches = havingValue.equals(propertyValue);
+        return matchIfMissing ? !matches : matches;
+    }
+}

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/org/apache/camel/forage/springboot/jdbc/jta/ForageTransactionManagementAutoConfiguration.java
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/main/java/org/apache/camel/forage/springboot/jdbc/jta/ForageTransactionManagementAutoConfiguration.java
@@ -1,0 +1,105 @@
+package org.apache.camel.forage.springboot.jdbc.jta;
+
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.UserTransactionImple;
+import jakarta.annotation.PostConstruct;
+import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
+import org.apache.camel.forage.springboot.jdbc.ConditionalOnForageProperty;
+import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.jta.JtaTransactionManager;
+
+@Configuration
+@ConditionalOnForageProperty(
+        configClass = DataSourceFactoryConfig.class,
+        property = "jdbc.transaction.enabled",
+        havingValue = "true")
+@EnableTransactionManagement
+public class ForageTransactionManagementAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(ForageTransactionManagementAutoConfiguration.class);
+
+    @PostConstruct
+    public void init() {
+        log.info("ForageTransactionManagementAutoConfiguration initialized - transaction management enabled");
+    }
+
+    @Bean
+    public JtaTransactionManager jtaTransactionManager() {
+        log.info("Creating JtaTransactionManager bean");
+
+        JtaTransactionManager transactionManager = new JtaTransactionManager(
+                new UserTransactionImple(), com.arjuna.ats.jta.TransactionManager.transactionManager());
+
+        transactionManager.setTransactionSynchronizationRegistry(new TransactionSynchronizationRegistryImple());
+        log.debug("JtaTransactionManager created successfully");
+        return transactionManager;
+    }
+
+    @Bean("PROPAGATION_REQUIRED")
+    public SpringTransactionPolicy propagationRequired(JtaTransactionManager jtaTransactionManager) {
+        SpringTransactionPolicy springTransactionPolicy =
+                createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_REQUIRED");
+
+        return springTransactionPolicy;
+    }
+
+    @Bean("NESTED")
+    public SpringTransactionPolicy nested(JtaTransactionManager jtaTransactionManager) {
+        SpringTransactionPolicy springTransactionPolicy =
+                createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_NESTED");
+
+        return springTransactionPolicy;
+    }
+
+    @Bean("MANDATORY")
+    public SpringTransactionPolicy mandatory(JtaTransactionManager jtaTransactionManager) {
+        SpringTransactionPolicy springTransactionPolicy =
+                createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_MANDATORY");
+
+        return springTransactionPolicy;
+    }
+
+    @Bean("NEVER")
+    public SpringTransactionPolicy never(JtaTransactionManager jtaTransactionManager) {
+        SpringTransactionPolicy springTransactionPolicy =
+                createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_NEVER");
+
+        return springTransactionPolicy;
+    }
+
+    @Bean("NOT_SUPPORTED")
+    public SpringTransactionPolicy notSupported(JtaTransactionManager jtaTransactionManager) {
+        SpringTransactionPolicy springTransactionPolicy =
+                createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_NOT_SUPPORTED");
+
+        return springTransactionPolicy;
+    }
+
+    @Bean("REQUIRES_NEW")
+    public SpringTransactionPolicy requiresNew(JtaTransactionManager jtaTransactionManager) {
+        SpringTransactionPolicy springTransactionPolicy =
+                createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_REQUIRES_NEW");
+
+        return springTransactionPolicy;
+    }
+
+    @Bean("SUPPORTS")
+    public SpringTransactionPolicy supports(JtaTransactionManager jtaTransactionManager) {
+        SpringTransactionPolicy springTransactionPolicy =
+                createSpringBootTransactionPolicy(jtaTransactionManager, "PROPAGATION_SUPPORTS");
+
+        return springTransactionPolicy;
+    }
+
+    private static SpringTransactionPolicy createSpringBootTransactionPolicy(
+            JtaTransactionManager jtaTransactionManager, String propagationBehavior) {
+        SpringTransactionPolicy springTransactionPolicy = new SpringTransactionPolicy(jtaTransactionManager);
+        springTransactionPolicy.setPropagationBehaviorName(propagationBehavior);
+        return springTransactionPolicy;
+    }
+}

--- a/library/jdbc/spring-boot/forage-jdbc-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/library/jdbc/spring-boot/forage-jdbc-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.apache.camel.forage.springboot.jdbc.ForageDataSourceAutoConfiguration
+org.apache.camel.forage.springboot.jdbc.jta.ForageTransactionManagementAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <javaparser.version>3.27.0</javaparser.version>
         <jackson.version>2.15.2</jackson.version>
         <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
+        <narayana.version>7.2.2.Final</narayana.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
@JiriOndrusek I used [properties that are like the quarkus ones](https://github.com/megacamelus/camel-forage/compare/main...Croway:jdbc-transactions?expand=1#diff-9c60b047676b887ee0bd6fcbb0ccd5d8db1bed06cc6457d4765172edb9b5551aR128-R212), hopefully the mapping will be easy.

* This PR introduces PropagationPolicy beans, the name of the beans are the ones used by Quarkus:

```
PROPAGATION_REQUIRED
MANDATORY
NEVER
NOT_SUPPORTED
REQUIRES_NEW
SUPPORTS
```

I hope that adding the quarkus properties and the jta camel quarkus extension the quarkus export should execute as expected.

I didn't do many tests, but this is working:

```
from("timer:java?period=1000")
                .transacted("REQUIRES_NEW")
                .to("sql:select * from bar")
                .log("from sql default ds - ${body}");
```

* [For Spring Boot I introduced a handy utility](https://github.com/megacamelus/camel-forage/compare/main...Croway:jdbc-transactions?expand=1#diff-af78643736494b5813077c206c8f92559222993c8fc27e4037163a07dc332bc0) that works like the usual ConditionalOnClass, but the forage properties are considered
```
@ConditionalOnForageProperty(
        configClass = DataSourceFactoryConfig.class,
        property = "jdbc.transaction.enabled",
        havingValue = "true")
```

* Th implementation classes (Postgres, MySql...) now produce XA Drivers if transactions are enabled