### PR TITLE
Adds forage run (export) for runtime Main

### DIFF
--- a/core/forage-core-common/src/main/java/org/apache/camel/forage/core/common/RuntimeType.java
+++ b/core/forage-core-common/src/main/java/org/apache/camel/forage/core/common/RuntimeType.java
@@ -5,6 +5,7 @@ package org.apache.camel.forage.core.common;
  * depend on cameljbang here, in commons module.
  */
 public enum RuntimeType {
+    main,
     quarkus,
     springBoot;
 }

--- a/library/jdbc/camel-quarkus/forage-quarkus-jdbc-configurer/src/main/java/org/apache/camel/forage/quarkus/jdbc/ForageDataSourceQuarkusConfigSource.java
+++ b/library/jdbc/camel-quarkus/forage-quarkus-jdbc-configurer/src/main/java/org/apache/camel/forage/quarkus/jdbc/ForageDataSourceQuarkusConfigSource.java
@@ -3,7 +3,9 @@ package org.apache.camel.forage.quarkus.jdbc;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.apache.camel.forage.core.common.RuntimeType;
 import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.jdbc.common.DataSourceCommonExportHelper;
 import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -34,7 +36,9 @@ public class ForageDataSourceQuarkusConfigSource implements ConfigSource {
             property = property + "\"" + prefix + "\".";
         }
 
-        configuration.put(property + "db-kind", config.dbKind());
+        configuration.put(
+                property + "db-kind",
+                DataSourceCommonExportHelper.getDbKindNameForRuntime(config.dbKind(), RuntimeType.quarkus));
         configuration.put(property + "password", config.password());
         configuration.put(property + "username", config.username());
         configuration.put(property + "jdbc.url", config.jdbcUrl());

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceCommonExportHelper.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceCommonExportHelper.java
@@ -1,5 +1,7 @@
 package org.apache.camel.forage.jdbc.common;
 
+import org.apache.camel.forage.core.common.RuntimeType;
+
 /**
  * Utility class for jdbc configuration value processing and transformation in the Camel Forage framework.
  */
@@ -22,5 +24,22 @@ public final class DataSourceCommonExportHelper {
 
         return "org.apache.camel.forage.jdbc.%s.%sJdbc"
                 .formatted(db, db.substring(0, 1).toUpperCase() + db.substring(1));
+    }
+
+    public static String getDbKindNameForRuntime(String dbKind, RuntimeType runtime) {
+        switch (runtime) {
+            case quarkus -> {
+                if ("postgres".equals(dbKind)) {
+                    return "postgresql";
+                }
+            }
+            case springBoot -> {
+                if ("postgresql".equals(dbKind)) {
+                    return "postgres";
+                }
+            }
+        }
+
+        return dbKind;
     }
 }

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/DataSourceExportHelper.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/DataSourceExportHelper.java
@@ -1,7 +1,6 @@
 package org.apache.camel.forage.plugin;
 
 import java.io.InputStream;
-import org.apache.camel.forage.core.common.RuntimeType;
 
 /**
  * Utility class for jdbc configuration value processing and transformation in the Camel Forage framework.
@@ -21,23 +20,6 @@ public final class DataSourceExportHelper {
      * </p>
      * */
     public static final String JDBC_PREFIXES_REGEXP = "(.+).jdbc\\..*";
-
-    public static String getDbKindNameForRuntime(String dbKind, RuntimeType runtime) {
-        switch (runtime) {
-            case quarkus -> {
-                if ("postgresql".equals(dbKind)) {
-                    return "postgresql";
-                }
-            }
-            case springBoot -> {
-                if ("postgresql".equals(dbKind)) {
-                    return "postgres";
-                }
-            }
-        }
-
-        return dbKind;
-    }
 
     /**
      * Gets the quarkus version from the versions.properties file. (which is populated during buildtime)

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/ForagePlugin.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/ForagePlugin.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
 import org.apache.camel.dsl.jbang.core.commands.Export;
-import org.apache.camel.dsl.jbang.core.commands.Run;
 import org.apache.camel.dsl.jbang.core.common.CamelJBangPlugin;
 import org.apache.camel.dsl.jbang.core.common.Plugin;
 import org.apache.camel.dsl.jbang.core.common.PluginExporter;
@@ -46,7 +45,7 @@ public class ForagePlugin implements Plugin {
                                         .addSubcommand(
                                                 "test-connection", new CommandLine(new TestDataSourceCommand(main))))
                         .addSubcommand("export", new Export(main))
-                        .addSubcommand("run", new Run(main)));
+                        .addSubcommand("run", new ForageRun(main)));
     }
 
     /**

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/ForageRun.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/ForageRun.java
@@ -1,0 +1,24 @@
+package org.apache.camel.forage.plugin;
+
+import org.apache.camel.dsl.jbang.core.commands.CamelJBangMain;
+import org.apache.camel.dsl.jbang.core.commands.Run;
+import org.apache.camel.forage.core.common.RuntimeType;
+import org.apache.camel.forage.plugin.datasource.DatasourceExportCustomizer;
+
+public class ForageRun extends Run {
+    public ForageRun(CamelJBangMain main) {
+        super(main);
+    }
+
+    /**
+     * This method is used only for the camel run command with runtime=main
+     * All other runtimes extends dependencies by interface {@link org.apache.camel.dsl.jbang.core.common.PluginExporter)
+     * from {@link org.apache.camel.forage.plugin.ForagePlugin}
+     */
+    @Override
+    protected void addDependencies(String... deps) {
+        super.addDependencies(new DatasourceExportCustomizer()
+                .resolveRuntimeDependencies(RuntimeType.main)
+                .toArray(new String[0]));
+    }
+}

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/datasource/DatasourceExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/datasource/DatasourceExportCustomizer.java
@@ -1,12 +1,14 @@
 package org.apache.camel.forage.plugin.datasource;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.camel.forage.core.common.ExportCustomizer;
 import org.apache.camel.forage.core.common.RuntimeType;
 import org.apache.camel.forage.core.util.config.ConfigStore;
+import org.apache.camel.forage.jdbc.common.DataSourceCommonExportHelper;
 import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
 import org.apache.camel.forage.plugin.DataSourceExportHelper;
 
@@ -23,7 +25,9 @@ public class DatasourceExportCustomizer implements ExportCustomizer {
     public Set<String> resolveRuntimeDependencies(RuntimeType runtime) {
         Set<String> dependencies = new HashSet<>();
 
-        switch (runtime) {
+        RuntimeType _runtime = runtime == null ? RuntimeType.main : runtime;
+
+        switch (_runtime) {
             case quarkus -> {
                 listDependencies(
                         dependencies,
@@ -39,6 +43,15 @@ public class DatasourceExportCustomizer implements ExportCustomizer {
                         Arrays.asList(
                                 "mvn:org.apache.camel.forage:forage-jdbc-starter:"
                                         + DataSourceExportHelper.geProjectVersion(),
+                                "mvn:org.apache.camel.forage:forage-jdbc:" + DataSourceExportHelper.geProjectVersion()),
+                        "mvn:org.apache.camel.forage:forage-jdbc-",
+                        ":" + DataSourceExportHelper.geProjectVersion(),
+                        runtime);
+            }
+            case main -> {
+                listDependencies(
+                        dependencies,
+                        Collections.singletonList(
                                 "mvn:org.apache.camel.forage:forage-jdbc:" + DataSourceExportHelper.geProjectVersion()),
                         "mvn:org.apache.camel.forage:forage-jdbc-",
                         ":" + DataSourceExportHelper.geProjectVersion(),
@@ -67,13 +80,13 @@ public class DatasourceExportCustomizer implements ExportCustomizer {
                     DataSourceFactoryConfig dsFactoryConfig = new DataSourceFactoryConfig(name);
                     // todoo get quarkus version
                     dependencies.add(depPrefix
-                            + DataSourceExportHelper.getDbKindNameForRuntime(dsFactoryConfig.dbKind(), runtime)
+                            + DataSourceCommonExportHelper.getDbKindNameForRuntime(dsFactoryConfig.dbKind(), runtime)
                             + depVersion);
                 }
             } else {
                 // todo get quarkus version
                 dependencies.add(depPrefix
-                        + DataSourceExportHelper.getDbKindNameForRuntime(config.dbKind(), runtime)
+                        + DataSourceCommonExportHelper.getDbKindNameForRuntime(config.dbKind(), runtime)
                         + depVersion);
             }
 


### PR DESCRIPTION
PR introduces forage run (export) for `main` runtime.

There is a light difference:
- Run commandfor runtimes Quarkus and Sprung-boot uses export command under the hood, therefore the implementation uses interface org.apache.camel.dsl.jbang.core.common.PluginExporter.
- Run commsnd for runtime =`main` does not run export command, therefore `ForageRun` cammand has to be introduced.

+ I added a small fix (caused by the allowed value for dbKind . Both `postgres` and `postgresql` now work correctly)