### PR TITLE
Quarkus - Use the same default ds name as csb

### DIFF
--- a/library/jdbc/camel-quarkus/forage-quarkus-jdbc-configurer/src/main/java/org/apache/camel/forage/quarkus/jdbc/ForageDataSourceQuarkusConfigSource.java
+++ b/library/jdbc/camel-quarkus/forage-quarkus-jdbc-configurer/src/main/java/org/apache/camel/forage/quarkus/jdbc/ForageDataSourceQuarkusConfigSource.java
@@ -26,7 +26,7 @@ public class ForageDataSourceQuarkusConfigSource implements ConfigSource {
                 configureDs(name, dsFactoryConfig);
             }
         } else {
-            configureDs(null, config);
+            configureDs("dataSource", config);
         }
     }
 


### PR DESCRIPTION
Use the same default ds name as spring-boot