### PR TITLE
Expose JDBCAggregationRepository bean

### DIFF
--- a/library/jdbc/forage-jdbc-common/pom.xml
+++ b/library/jdbc/forage-jdbc-common/pom.xml
@@ -27,6 +27,15 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jta</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-sql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>io.agroal</groupId>

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfig.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfig.java
@@ -210,4 +210,56 @@ public class DataSourceFactoryConfig implements Config {
                 .get(DataSourceFactoryConfigEntries.TRANSACTION_OBJECT_STORE_TABLE_PREFIX.asNamed(prefix))
                 .orElse("forage_");
     }
+
+    public String aggregationRepositoryName() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_NAME.asNamed(prefix))
+                .orElse(null);
+    }
+
+    public String aggregationRepositoryHeadersToStore() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_HEADERS_TO_STORE.asNamed(prefix))
+                .orElse(null);
+    }
+
+    public Boolean aggregationRepositoryStoreBody() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_STORE_BODY.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(null);
+    }
+
+    public String aggregationRepositoryDeadLetterUri() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_DEAD_LETTER_URI.asNamed(prefix))
+                .orElse(null);
+    }
+
+    public Boolean aggregationRepositoryAllowSerializedHeaders() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_ALLOW_SERIALIZED_HEADERS.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(null);
+    }
+
+    public Integer aggregationRepositoryMaximumRedeliveries() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_MAXIMUM_REDELIVERIES.asNamed(prefix))
+                .map(Integer::parseInt)
+                .orElse(null);
+    }
+
+    public Boolean aggregationRepositoryUseRecovery() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_USE_RECOVERY.asNamed(prefix))
+                .map(Boolean::parseBoolean)
+                .orElse(null);
+    }
+
+    public String aggregationRepositoryPropagationBehaviourName() {
+        return ConfigStore.getInstance()
+                .get(DataSourceFactoryConfigEntries.AGGREGATION_REPOSITORY_PROPAGATION_BEHAVIOUR_NAME.asNamed(prefix))
+                .orElse(null);
+    }
 }

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfigEntries.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/DataSourceFactoryConfigEntries.java
@@ -65,6 +65,22 @@ public class DataSourceFactoryConfigEntries extends ConfigEntries {
             ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.drop.table");
     public static final ConfigModule TRANSACTION_OBJECT_STORE_TABLE_PREFIX =
             ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.transaction.object.store.table.prefix");
+    public static final ConfigModule AGGREGATION_REPOSITORY_NAME =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.name");
+    public static final ConfigModule AGGREGATION_REPOSITORY_HEADERS_TO_STORE =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.headers.to.store");
+    public static final ConfigModule AGGREGATION_REPOSITORY_STORE_BODY =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.store.body");
+    public static final ConfigModule AGGREGATION_REPOSITORY_DEAD_LETTER_URI =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.dead.letter.uri");
+    public static final ConfigModule AGGREGATION_REPOSITORY_ALLOW_SERIALIZED_HEADERS =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.allow.serialized.headers");
+    public static final ConfigModule AGGREGATION_REPOSITORY_MAXIMUM_REDELIVERIES =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.maximum.redeliveries");
+    public static final ConfigModule AGGREGATION_REPOSITORY_USE_RECOVERY =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.use.recovery");
+    public static final ConfigModule AGGREGATION_REPOSITORY_PROPAGATION_BEHAVIOUR_NAME =
+            ConfigModule.of(DataSourceFactoryConfig.class, "jdbc.aggregation.repository.propagation.behaviour.name");
 
     private static final Map<ConfigModule, ConfigEntry> CONFIG_MODULES = new ConcurrentHashMap<>();
 
@@ -100,6 +116,14 @@ public class DataSourceFactoryConfigEntries extends ConfigEntries {
         CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_CREATE_TABLE, ConfigEntry.fromModule());
         CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_DROP_TABLE, ConfigEntry.fromModule());
         CONFIG_MODULES.put(TRANSACTION_OBJECT_STORE_TABLE_PREFIX, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_NAME, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_HEADERS_TO_STORE, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_STORE_BODY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_DEAD_LETTER_URI, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_ALLOW_SERIALIZED_HEADERS, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_MAXIMUM_REDELIVERIES, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_USE_RECOVERY, ConfigEntry.fromModule());
+        CONFIG_MODULES.put(AGGREGATION_REPOSITORY_PROPAGATION_BEHAVIOUR_NAME, ConfigEntry.fromModule());
     }
 
     public static Map<ConfigModule, ConfigEntry> entries() {

--- a/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/aggregation/ForageAggregationRepository.java
+++ b/library/jdbc/forage-jdbc-common/src/main/java/org/apache/camel/forage/jdbc/common/aggregation/ForageAggregationRepository.java
@@ -1,0 +1,28 @@
+package org.apache.camel.forage.jdbc.common.aggregation;
+
+import jakarta.transaction.TransactionManager;
+import javax.sql.DataSource;
+import org.apache.camel.forage.jdbc.common.DataSourceFactoryConfig;
+import org.apache.camel.processor.aggregate.jdbc.JdbcAggregationRepository;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+
+public class ForageAggregationRepository extends JdbcAggregationRepository {
+
+    public ForageAggregationRepository(
+            DataSource dataSource,
+            TransactionManager transactionManager,
+            DataSourceFactoryConfig dataSourceFactoryConfig) {
+        setRepositoryName(dataSourceFactoryConfig.aggregationRepositoryName());
+        setDataSource(dataSource);
+        DataSourceTransactionManager dataSourceTransactionManager = new DataSourceTransactionManager(dataSource);
+        setTransactionManager(dataSourceTransactionManager);
+
+        setHeadersToStoreAsText(dataSourceFactoryConfig.aggregationRepositoryHeadersToStore()); // comma separated list
+        setStoreBodyAsText(dataSourceFactoryConfig.aggregationRepositoryStoreBody());
+        setDeadLetterUri(dataSourceFactoryConfig.aggregationRepositoryDeadLetterUri());
+        setAllowSerializedHeaders(dataSourceFactoryConfig.aggregationRepositoryAllowSerializedHeaders());
+        setMaximumRedeliveries(dataSourceFactoryConfig.aggregationRepositoryMaximumRedeliveries());
+        setUseRecovery(dataSourceFactoryConfig.aggregationRepositoryUseRecovery());
+        setPropagationBehaviorName(dataSourceFactoryConfig.aggregationRepositoryPropagationBehaviourName());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <assertj-core.version>3.27.4</assertj-core.version>
         <testcontainers.version>1.21.3</testcontainers.version>
         <agroal.version>2.8</agroal.version>
+        <spring.version>6.2.11</spring.version>
         <spring-boot.version>3.5.5</spring-boot.version>
         <quarkus.version>3.26.4</quarkus.version>
         <maven.version>3.9.11</maven.version>

--- a/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/datasource/DatasourceExportCustomizer.java
+++ b/tooling/camel-jbang-plugin-forage/src/main/java/org/apache/camel/forage/plugin/datasource/DatasourceExportCustomizer.java
@@ -88,7 +88,7 @@ public class DatasourceExportCustomizer implements ExportCustomizer {
                         + depVersion);
             }
 
-            if(config.transactionEnabled()) {
+            if (config.transactionEnabled()) {
                 dependencies.add("mvn:io.quarkus:quarkus-narayana-jta:" + DataSourceExportHelper.getQuarkusVersion());
             }
         } catch (Exception ex) {


### PR DESCRIPTION
the properties

```
jdbc.transaction.enabled=true
jdbc.aggregation.repository.name=myAggregation
```

are required to enable the aggregation repository. the  `jdbc.aggregation.repository.name` is the name of the produced bean, and the tables. In particular, for a repository named `myAggregation` the following table need to be created:

```
CREATE TABLE myAggregation (
    id VARCHAR(255) NOT NULL,
    exchange BLOB NOT NULL,
    version BIGINT NOT NULL,
    CONSTRAINT aggregation_repository_pk PRIMARY KEY (id)
);

CREATE TABLE myAggregation (
 id varchar(255) NOT NULL,
 exchange BLOB NOT NULL,
 version BIGINT NOT NULL,
 constraint aggregation_completed_pk PRIMARY KEY (id)
);
```

The created repository can than be used in Camel aggregate EIP, as `aggregationRepository`

```
- aggregate:
            id: aggregate-batch
            steps:
              - log:
                  id: log-complete
                  message: "Batch complete with ${exchangeProperty.CamelAggregatedSize} event id:
                    ${header.eventId} and events: ${body}"
            aggregationRepository: "#myAggregation"
            aggregationStrategy: "#groupedBodyAggregationStrategy"
            completionSize: 5
            completionTimeout: "50000"
            correlationExpression:
              header:
                expression: eventId
```